### PR TITLE
feat: デザインSSOT → 静的UI骨格生成（3画面）

### DIFF
--- a/doc/input/design/components.json
+++ b/doc/input/design/components.json
@@ -1,5 +1,5 @@
 {
-  "meta": { "version": 1 },
+  "meta": { "version": 2, "source": "Pencil MCP x-clone-mvp.pen", "updated": "2026-03-18" },
   "components": [
     {
       "name": "Sidebar",
@@ -8,16 +8,43 @@
       "defaults": {},
       "slots": ["logo", "navigation", "currentUser"],
       "styles": {
-        "backgroundColorRef": "semantic.color.surface.card",
-        "border": {
-          "colorRef": "semantic.color.border.subtle",
+        "fillRef": "semantic.color.surface.sidebarGlass",
+        "fillOverlay": {
+          "type": "gradient",
+          "ref": "primitives.gradient.sidebarWarmOverlay",
+          "note": "サイドバー背景に暖色グラデーションオーバーレイを重ねる"
+        },
+        "effectRef": "semantic.color.surfaceEffect.sidebarBlur",
+        "stroke": {
+          "colorRef": "semantic.color.border.glass",
           "widthRef": "primitives.border.width.1",
           "styleRef": "primitives.border.style.solid",
           "alignRef": "primitives.border.align.inside",
           "sides": ["right"]
         },
         "width": "280px",
-        "paddingRef": "primitives.space.8"
+        "paddingRef": ["primitives.space.8", "primitives.space.6"],
+        "note": "padding: 32px 24px。backdrop-blur: 16px"
+      },
+      "children": {
+        "logoArea": {
+          "layout": "horizontal",
+          "alignItems": "center",
+          "gapRef": "primitives.space.3",
+          "paddingBottom": "primitives.space.6",
+          "icon": { "family": "lucide", "name": "leaf", "size": "28px", "colorRef": "semantic.color.accent.primary" },
+          "text": { "content": "copyKey:app.name", "fontSizeRef": "primitives.font.size.xl", "fontWeightRef": "primitives.font.weight.bold", "colorRef": "semantic.color.text.primary" }
+        },
+        "currentUser": {
+          "layout": "horizontal",
+          "alignItems": "center",
+          "gapRef": "primitives.space.3",
+          "paddingTop": "primitives.space.4",
+          "borderTop": { "colorRef": "semantic.color.border.subtle", "widthRef": "primitives.border.width.1" },
+          "avatar": { "size": "40px", "fillRef": "semantic.color.accent.muted", "shape": "ellipse" },
+          "name": { "fontSizeRef": "primitives.font.size.md", "fontWeightRef": "primitives.font.weight.semibold", "colorRef": "semantic.color.text.primary" },
+          "handle": { "fontSizeRef": "primitives.font.size.xs", "fontWeightRef": "primitives.font.weight.regular", "colorRef": "semantic.color.text.tertiary" }
+        }
       },
       "a11y": {
         "role": "navigation",
@@ -26,26 +53,34 @@
     },
     {
       "name": "NavItem",
-      "description": "サイドバー内のナビゲーション項目。アイコン＋ラベル",
+      "description": "サイドバー内のナビゲーション項目。Lucideアイコン＋ラベル",
       "variants": {
         "state": ["default", "active"]
       },
       "defaults": { "state": "default" },
       "slots": ["icon", "label"],
       "styles": {
+        "layout": "horizontal",
+        "alignItems": "center",
+        "gapRef": "primitives.space.3",
+        "radiusRef": "semantic.radius.nav",
+        "paddingRef": ["primitives.space.3", "primitives.space.4"],
+        "note": "padding: 12px 16px, cornerRadius: 12px, gap: 12px",
         "state:default": {
           "backgroundColorRef": "transparent",
           "textColorRef": "semantic.color.text.secondary",
+          "textFontWeightRef": "primitives.font.weight.medium",
           "iconColorRef": "semantic.color.text.secondary"
         },
         "state:active": {
-          "backgroundColorRef": "semantic.color.surface.hover",
+          "backgroundColorRef": "semantic.color.surface.navActive",
           "textColorRef": "semantic.color.text.primary",
+          "textFontWeightRef": "primitives.font.weight.semibold",
           "iconColorRef": "semantic.color.accent.primary"
         },
-        "radiusRef": "semantic.radius.nav",
-        "paddingRef": ["primitives.space.3", "primitives.space.4"],
-        "gapRef": "primitives.space.3"
+        "textFontSizeRef": "primitives.font.size.base",
+        "iconSize": "20px",
+        "iconFamily": "lucide"
       },
       "a11y": {
         "role": "link",
@@ -55,21 +90,44 @@
     },
     {
       "name": "PostCard",
-      "description": "投稿カード。アバター＋ユーザー情報＋投稿内容を表示",
+      "description": "投稿カード。アバター（ellipse）＋投稿本文（ヘッダー＋コンテンツ）を横並び",
       "variants": {},
       "defaults": {},
       "slots": ["avatar", "authorName", "handle", "timestamp", "content"],
       "styles": {
-        "backgroundColorRef": "semantic.color.surface.card",
-        "border": {
-          "colorRef": "semantic.color.border.subtle",
+        "layout": "horizontal",
+        "fillRef": "semantic.color.surface.cardGlass",
+        "effectRef": "semantic.color.surfaceEffect.cardBlur",
+        "stroke": {
+          "colorRef": "semantic.color.border.glass",
           "widthRef": "primitives.border.width.1",
           "styleRef": "primitives.border.style.solid",
           "alignRef": "primitives.border.align.inside"
         },
         "radiusRef": "semantic.radius.card",
         "paddingRef": "primitives.space.5",
-        "gapRef": "primitives.space.3"
+        "gapRef": "primitives.space.3",
+        "note": "padding: 20px, gap: 12px, cornerRadius: 16px, backdrop-blur: 12px",
+        "avatar": { "size": "40px", "shape": "ellipse" },
+        "body": {
+          "layout": "vertical",
+          "gapRef": "primitives.space.2",
+          "note": "gap: 8px between header and content"
+        },
+        "header": {
+          "layout": "horizontal",
+          "alignItems": "center",
+          "gapRef": "primitives.space.2",
+          "authorName": { "fontSizeRef": "primitives.font.size.base", "fontWeightRef": "primitives.font.weight.semibold", "colorRef": "semantic.color.text.primary" },
+          "handle": { "fontSizeRef": "primitives.font.size.sm", "colorRef": "semantic.color.text.tertiary" },
+          "timestamp": { "fontSizeRef": "primitives.font.size.sm", "colorRef": "semantic.color.text.tertiary" }
+        },
+        "content": {
+          "fontSizeRef": "primitives.font.size.base",
+          "fontWeightRef": "primitives.font.weight.regular",
+          "lineHeightRef": "primitives.font.lineHeight.relaxed",
+          "colorRef": "semantic.color.text.primary"
+        }
       },
       "a11y": {
         "role": "article",
@@ -78,21 +136,32 @@
     },
     {
       "name": "UserCard",
-      "description": "ユーザー一覧カード。アバター＋名前＋ハンドル＋フォローボタン",
+      "description": "ユーザー一覧カード。アバター（48px ellipse）＋名前＋ハンドル＋フォローボタン",
       "variants": {},
       "defaults": {},
       "slots": ["avatar", "name", "handle", "followButton"],
       "styles": {
-        "backgroundColorRef": "semantic.color.surface.card",
-        "border": {
-          "colorRef": "semantic.color.border.subtle",
+        "layout": "horizontal",
+        "alignItems": "center",
+        "fillRef": "semantic.color.surface.cardGlass",
+        "effectRef": "semantic.color.surfaceEffect.cardBlur",
+        "stroke": {
+          "colorRef": "semantic.color.border.glass",
           "widthRef": "primitives.border.width.1",
           "styleRef": "primitives.border.style.solid",
           "alignRef": "primitives.border.align.inside"
         },
         "radiusRef": "semantic.radius.card",
         "paddingRef": "primitives.space.5",
-        "gapRef": "primitives.space.4"
+        "gapRef": "primitives.space.4",
+        "note": "padding: 20px, gap: 16px, cornerRadius: 16px, backdrop-blur: 12px",
+        "avatar": { "size": "48px", "shape": "ellipse" },
+        "info": {
+          "layout": "vertical",
+          "gapRef": "primitives.space.1",
+          "name": { "fontSizeRef": "primitives.font.size.base", "fontWeightRef": "primitives.font.weight.semibold", "colorRef": "semantic.color.text.primary" },
+          "handle": { "fontSizeRef": "primitives.font.size.sm", "colorRef": "semantic.color.text.tertiary" }
+        }
       },
       "a11y": {
         "role": "article",
@@ -111,18 +180,28 @@
       "slots": ["label"],
       "styles": {
         "tone:primary": {
-          "backgroundColorRef": "semantic.color.accent.primary",
-          "textColorRef": "semantic.color.accent.onAccent"
+          "fillRef": "semantic.color.accent.buttonGradient",
+          "textColorRef": "semantic.color.accent.onAccent",
+          "effectRef": "semantic.color.accent.glowShadow",
+          "note": "gradient: 135deg #8BAA7F→#A8D4A0, shadow: 0 2px 12px rgba(139,170,127,0.19)"
         },
         "tone:outline": {
-          "backgroundColorRef": "transparent",
+          "fillRef": "transparent",
           "textColorRef": "semantic.color.accent.primary",
-          "border": {
-            "colorRef": "semantic.color.accent.primary",
+          "stroke": {
+            "type": "gradient",
+            "colorStart": "primitives.color.sage.300",
+            "colorEnd": "primitives.color.sage.500",
+            "rotation": "135deg",
             "widthRef": "primitives.border.width.1"
-          }
+          },
+          "effectRef": "primitives.shadow.glowAccentSubtle",
+          "note": "ボーダーがグラデーション。shadow: 0 1px 8px rgba(139,170,127,0.09)"
         },
-        "radiusRef": "semantic.radius.button"
+        "size:sm": { "paddingRef": ["primitives.space.2", "primitives.space.5"], "fontSizeRef": "primitives.font.size.sm", "note": "padding: 8px 20px" },
+        "size:md": { "paddingRef": ["primitives.space.3-minus2", "primitives.space.6"], "fontSizeRef": "primitives.font.size.md", "note": "padding: 10px 24px" },
+        "radiusRef": "semantic.radius.button",
+        "textFontWeightRef": "primitives.font.weight.semibold"
       },
       "a11y": {
         "role": "button",
@@ -132,21 +211,35 @@
     },
     {
       "name": "Composer",
-      "description": "投稿入力エリア。アバター＋テキスト入力＋文字数カウント＋投稿ボタン",
+      "description": "投稿入力エリア。アバター＋テキスト入力（上段）＋文字数カウント＋投稿ボタン（下段）",
       "variants": {},
       "defaults": {},
       "slots": ["avatar", "input", "charCount", "submitButton"],
       "styles": {
-        "backgroundColorRef": "semantic.color.surface.card",
-        "border": {
-          "colorRef": "semantic.color.border.subtle",
+        "layout": "vertical",
+        "fillRef": "semantic.color.surface.cardGlass",
+        "effectRef": "semantic.color.surfaceEffect.cardBlur",
+        "stroke": {
+          "colorRef": "semantic.color.border.glass",
           "widthRef": "primitives.border.width.1",
           "styleRef": "primitives.border.style.solid",
           "alignRef": "primitives.border.align.inside"
         },
         "radiusRef": "semantic.radius.card",
         "paddingRef": "primitives.space.5",
-        "gapRef": "primitives.space.4"
+        "gapRef": "primitives.space.4",
+        "note": "padding: 20px, gap: 16px, cornerRadius: 16px. 2段構成: top(avatar+input) / bottom(charCount+button)",
+        "top": {
+          "layout": "horizontal",
+          "gapRef": "primitives.space.3",
+          "avatar": { "size": "40px", "shape": "ellipse", "fillRef": "semantic.color.accent.muted" }
+        },
+        "bottom": {
+          "layout": "horizontal",
+          "justifyContent": "end",
+          "alignItems": "center",
+          "gapRef": "primitives.space.3"
+        }
       },
       "a11y": {
         "role": "form",
@@ -156,21 +249,49 @@
     },
     {
       "name": "ProfileHeader",
-      "description": "プロフィール画面のヘッダー。アバター＋名前＋ハンドル＋フォローボタン＋フォロー数/フォロワー数",
+      "description": "プロフィール画面のヘッダー。アバター＋名前＋ハンドル＋bio＋フォローボタン＋フォロー数/フォロワー数",
       "variants": {},
       "defaults": {},
-      "slots": ["avatar", "name", "handle", "followButton", "followingCount", "followersCount"],
+      "slots": ["avatar", "name", "handle", "bio", "followButton", "followingCount", "followersCount"],
       "styles": {
-        "backgroundColorRef": "semantic.color.surface.card",
-        "border": {
-          "colorRef": "semantic.color.border.subtle",
+        "layout": "vertical",
+        "fillRef": "semantic.color.surface.cardGlass",
+        "effectRef": "semantic.color.surfaceEffect.cardBlur",
+        "stroke": {
+          "colorRef": "semantic.color.border.glass",
           "widthRef": "primitives.border.width.1",
           "styleRef": "primitives.border.style.solid",
           "alignRef": "primitives.border.align.inside"
         },
         "radiusRef": "semantic.radius.card",
-        "paddingRef": "primitives.space.6",
-        "gapRef": "primitives.space.5"
+        "paddingRef": ["primitives.space.6", "primitives.space.6", "primitives.space.5", "primitives.space.6"],
+        "gapRef": "primitives.space.4",
+        "note": "padding: 24px 24px 20px 24px, gap: 16px, cornerRadius: 16px",
+        "top": {
+          "layout": "horizontal",
+          "gapRef": "primitives.space.4",
+          "avatar": { "size": "64px", "shape": "ellipse" },
+          "info": {
+            "layout": "vertical",
+            "gapRef": "primitives.space.0-half",
+            "name": { "fontSizeRef": "primitives.font.size.xl", "fontWeightRef": "primitives.font.weight.bold", "colorRef": "semantic.color.text.primary" },
+            "handle": { "fontSizeRef": "primitives.font.size.sm", "colorRef": "semantic.color.text.tertiary" }
+          }
+        },
+        "bio": {
+          "fontSizeRef": "primitives.font.size.md",
+          "lineHeightRef": "primitives.font.lineHeight.relaxed",
+          "colorRef": "semantic.color.text.secondary"
+        },
+        "stats": {
+          "layout": "horizontal",
+          "gap": "32px",
+          "paddingTop": "primitives.space.3",
+          "borderTop": { "colorRef": "semantic.color.border.subtle", "widthRef": "primitives.border.width.1" },
+          "count": { "fontSizeRef": "primitives.font.size.lg", "fontWeightRef": "primitives.font.weight.bold", "colorRef": "semantic.color.text.primary" },
+          "label": { "fontSizeRef": "primitives.font.size.md", "colorRef": "semantic.color.text.secondary" },
+          "itemGap": "6px"
+        }
       },
       "a11y": {
         "role": "banner",

--- a/doc/input/design/copy.json
+++ b/doc/input/design/copy.json
@@ -1,5 +1,5 @@
 {
-  "meta": { "version": 1 },
+  "meta": { "version": 2, "source": "Pencil MCP x-clone-mvp.pen", "updated": "2026-03-18" },
   "defaultLocale": "ja-JP",
   "locales": {
     "ja-JP": {
@@ -10,17 +10,41 @@
         "nav.profile": "プロフィール",
         "currentUser.name": "さくら",
         "currentUser.handle": "@sakura",
-        "profilePage.bio.sakura": "お茶と読書が好き。静かな夜のひとときを大切にしています。",
         "timelinePage.title": "タイムライン",
         "timelinePage.composer.placeholder": "いまどうしてる？",
         "timelinePage.composer.charCount": "0/140",
         "timelinePage.composer.submit": "投稿する",
+        "timelinePage.post1.authorName": "さくら",
+        "timelinePage.post1.handle": "@sakura",
+        "timelinePage.post1.timestamp": "2時間前",
+        "timelinePage.post1.content": "今日も一日お疲れさまでした。夜風が気持ちいい季節になりましたね。窓を開けて深呼吸すると、少しだけ心が軽くなる気がします。",
+        "timelinePage.post2.authorName": "はると",
+        "timelinePage.post2.handle": "@haruto",
+        "timelinePage.post2.timestamp": "4時間前",
+        "timelinePage.post2.content": "近所のカフェで見つけた新しいブレンド、すごく美味しかった。明日も行こうかな。",
+        "timelinePage.post3.authorName": "ゆき",
+        "timelinePage.post3.handle": "@yuki",
+        "timelinePage.post3.timestamp": "6時間前",
+        "timelinePage.post3.content": "読みかけの本をやっと読み終えた。静かな夜に読書するのが最高の贅沢。",
         "usersPage.title": "ユーザー一覧",
         "usersPage.followButton.follow": "フォロー",
         "usersPage.followButton.following": "フォロー中",
+        "usersPage.user1.name": "さくら",
+        "usersPage.user1.handle": "@sakura",
+        "usersPage.user2.name": "はると",
+        "usersPage.user2.handle": "@haruto",
+        "usersPage.user3.name": "ゆき",
+        "usersPage.user3.handle": "@yuki",
+        "usersPage.user4.name": "りく",
+        "usersPage.user4.handle": "@riku",
+        "usersPage.user5.name": "あおい",
+        "usersPage.user5.handle": "@aoi",
         "profilePage.postsLabel": "投稿",
         "profilePage.stats.following": "フォロー中",
-        "profilePage.stats.followers": "フォロワー"
+        "profilePage.stats.followers": "フォロワー",
+        "profilePage.bio.sakura": "お茶と読書が好き。静かな夜のひとときを大切にしています。",
+        "profilePage.post1.content": "今日も一日お疲れさまでした。夜風が気持ちいい季節になりましたね。窓を開けて深呼吸すると、少しだけ心が軽くなる気がします。",
+        "profilePage.post2.content": "雨上がりの空がきれいだった。虹は見えなかったけど、雲の隙間から差す光がとても穏やかで。"
       }
     }
   }

--- a/doc/input/design/design-tokens.json
+++ b/doc/input/design/design-tokens.json
@@ -1,5 +1,5 @@
 {
-  "meta": { "version": 1 },
+  "meta": { "version": 2, "source": "Pencil MCP x-clone-mvp.pen", "updated": "2026-03-18" },
   "primitives": {
     "color": {
       "stone": {
@@ -22,6 +22,7 @@
         "glow": "#D4A57410"
       },
       "glass": {
+        "sidebar": "#FFFFFF08",
         "card": "#FFFFFF0D",
         "border": "#FFFFFF0F"
       },
@@ -31,7 +32,8 @@
       },
       "blue": {
         "muted": "#5B9BD526"
-      }
+      },
+      "navActive": "#33302C"
     },
     "border": {
       "width": { "0": "0px", "1": "1px" },
@@ -85,11 +87,14 @@
     "shadow": {
       "card": "0 2px 8px rgba(0,0,0,0.12)",
       "glowAccent": "0 2px 12px rgba(139,170,127,0.19)",
-      "glowAccentSubtle": "0 1px 8px rgba(139,170,127,0.09)"
+      "glowAccentSubtle": "0 1px 8px rgba(139,170,127,0.09)",
+      "glowAccentButton": "0 2px 12px rgba(139,170,127,0.19)",
+      "glowOutlineSubtle": "0 1px 8px rgba(139,170,127,0.09)"
     },
     "gradient": {
       "accentButton": "linear-gradient(135deg, #8BAA7F 0%, #A8D4A0 100%)",
-      "warmGlow": "radial-gradient(ellipse at 55% 30%, rgba(212,165,116,0.06) 0%, transparent 100%)"
+      "warmGlow": "radial-gradient(ellipse at 55% 30%, rgba(212,165,116,0.06) 0%, transparent 100%)",
+      "sidebarWarmOverlay": "linear-gradient(180deg, rgba(212,165,116,0.03) 0%, #1C1917 100%)"
     },
     "blur": {
       "glass": "12px",
@@ -100,6 +105,19 @@
       "md": "768px",
       "lg": "1024px",
       "xl": "1440px"
+    },
+    "icon": {
+      "family": "lucide",
+      "size": {
+        "nav": "20px",
+        "logo": "28px"
+      },
+      "names": {
+        "logo": "leaf",
+        "timeline": "newspaper",
+        "users": "users",
+        "profile": "user"
+      }
     }
   },
   "semantic": {
@@ -113,18 +131,20 @@
         "page": { "ref": "primitives.color.stone.900" },
         "card": { "ref": "primitives.color.stone.800" },
         "cardGlass": { "ref": "primitives.color.glass.card", "note": "グラスモーフィズム用。backdrop-blur併用" },
+        "sidebarGlass": { "ref": "primitives.color.glass.sidebar", "note": "サイドバー背景。backdrop-blur+gradient併用" },
         "elevated": { "ref": "primitives.color.stone.700" },
-        "hover": { "ref": "primitives.color.stone.800", "note": "#33302C は実装時に微調整可" }
+        "navActive": { "ref": "primitives.color.navActive", "note": "#33302C ナビゲーションのactive背景" }
       },
       "surfaceEffect": {
         "pageGlow": { "ref": "primitives.gradient.warmGlow", "note": "ページ背景のラジアルグロー" },
+        "sidebarOverlay": { "ref": "primitives.gradient.sidebarWarmOverlay", "note": "サイドバーの暖色グラデーションオーバーレイ" },
         "cardBlur": { "ref": "primitives.blur.glass", "note": "カードのbackdrop-blur" },
         "sidebarBlur": { "ref": "primitives.blur.glassSidebar", "note": "サイドバーのbackdrop-blur" }
       },
       "border": {
-        "default": { "ref": "primitives.color.stone.700", "note": "#3D3730 実装時に微調整可" },
-        "subtle": { "ref": "primitives.color.stone.800", "note": "#2E2A25 実装時に微調整可" },
-        "glass": { "ref": "primitives.color.glass.border", "note": "グラスカード用の極薄白ボーダー" }
+        "default": { "ref": "primitives.color.stone.700" },
+        "subtle": { "value": "#2E2A25", "note": "CurrentUser上部ボーダー・ProfileStats上部ボーダー" },
+        "glass": { "ref": "primitives.color.glass.border", "note": "グラスカード・サイドバー用の極薄白ボーダー" }
       },
       "accent": {
         "primary": { "ref": "primitives.color.sage.300" },
@@ -145,15 +165,17 @@
       }
     },
     "space": {
-      "page": { "ref": "primitives.space.8" },
-      "section": { "ref": "primitives.space.6" },
-      "card": { "ref": "primitives.space.5" },
-      "element": { "ref": "primitives.space.4" }
+      "page": { "ref": "primitives.space.8", "note": "32px" },
+      "pageHorizontal": { "ref": "primitives.space.12", "note": "48px メインコンテンツの左右パディング" },
+      "section": { "ref": "primitives.space.6", "note": "24px" },
+      "card": { "ref": "primitives.space.5", "note": "20px" },
+      "element": { "ref": "primitives.space.4", "note": "16px" },
+      "cardGap": { "ref": "primitives.space.3", "note": "12px カード間の隙間" }
     },
     "radius": {
-      "card": { "ref": "primitives.radius.lg" },
-      "button": { "ref": "primitives.radius.full" },
-      "nav": { "ref": "primitives.radius.md" }
+      "card": { "ref": "primitives.radius.lg", "note": "16px" },
+      "button": { "ref": "primitives.radius.full", "note": "999px" },
+      "nav": { "ref": "primitives.radius.md", "note": "12px" }
     }
   }
 }

--- a/doc/input/design/design_context.json
+++ b/doc/input/design/design_context.json
@@ -1,5 +1,5 @@
 {
-  "meta": { "version": 1 },
+  "meta": { "version": 2, "source": "Pencil MCP x-clone-mvp.pen", "updated": "2026-03-18" },
   "viewports": {
     "desktop": { "width": 1440, "height": 900 },
     "mobile": { "width": 390, "height": 844 }
@@ -16,7 +16,7 @@
           "layout": {
             "type": "autoLayout",
             "direction": "vertical",
-            "paddingTokenRef": "primitives.space.8"
+            "paddingTokenRef": ["primitives.space.8", "primitives.space.6"]
           },
           "constraints": { "horizontal": "LEFT", "vertical": "TOP_BOTTOM" },
           "resizing": { "horizontal": "FIXED", "vertical": "FILL" }
@@ -27,16 +27,18 @@
             "type": "autoLayout",
             "direction": "vertical",
             "gapTokenRef": "primitives.space.6",
-            "paddingTokenRef": "primitives.space.8"
+            "paddingTokenRef": ["primitives.space.8", "primitives.space.12"]
           },
           "constraints": { "horizontal": "SCALE", "vertical": "TOP_BOTTOM" },
           "resizing": { "horizontal": "FILL", "vertical": "FILL" },
+          "clip": true,
           "nodes": [
             {
               "key": "PageTitle",
               "type": "text",
               "copyKey": "timelinePage.title",
               "typographyTokenRef": "primitives.font.size.3xl",
+              "fontWeightRef": "primitives.font.weight.bold",
               "colorTokenRef": "semantic.color.text.primary"
             },
             {
@@ -72,16 +74,18 @@
             "type": "autoLayout",
             "direction": "vertical",
             "gapTokenRef": "primitives.space.6",
-            "paddingTokenRef": "primitives.space.8"
+            "paddingTokenRef": ["primitives.space.8", "primitives.space.12"]
           },
           "constraints": { "horizontal": "SCALE", "vertical": "TOP_BOTTOM" },
           "resizing": { "horizontal": "FILL", "vertical": "FILL" },
+          "clip": true,
           "nodes": [
             {
               "key": "PageTitle",
               "type": "text",
               "copyKey": "usersPage.title",
               "typographyTokenRef": "primitives.font.size.3xl",
+              "fontWeightRef": "primitives.font.weight.bold",
               "colorTokenRef": "semantic.color.text.primary"
             },
             {
@@ -100,7 +104,7 @@
     },
     {
       "key": "ProfilePage",
-      "description": "プロフィール画面。選択したユーザーの情報（名前/ハンドル/フォロー数/フォロワー数）＋そのユーザーの投稿一覧を表示。",
+      "description": "プロフィール画面。選択したユーザーの情報＋フォロー数/フォロワー数＋投稿一覧を表示。",
       "primaryAction": "ユーザーをフォロー/アンフォローする",
       "frames": [
         {
@@ -113,10 +117,11 @@
             "type": "autoLayout",
             "direction": "vertical",
             "gapTokenRef": "primitives.space.6",
-            "paddingTokenRef": "primitives.space.8"
+            "paddingTokenRef": ["primitives.space.8", "primitives.space.12"]
           },
           "constraints": { "horizontal": "SCALE", "vertical": "TOP_BOTTOM" },
           "resizing": { "horizontal": "FILL", "vertical": "FILL" },
+          "clip": true,
           "nodes": [
             {
               "key": "ProfileHeader",
@@ -125,12 +130,18 @@
             {
               "key": "PostsSection",
               "type": "section",
+              "layout": {
+                "type": "autoLayout",
+                "direction": "vertical",
+                "gapTokenRef": "primitives.space.3"
+              },
               "nodes": [
                 {
                   "key": "SectionLabel",
                   "type": "text",
                   "copyKey": "profilePage.postsLabel",
                   "typographyTokenRef": "primitives.font.size.lg",
+                  "fontWeightRef": "primitives.font.weight.semibold",
                   "colorTokenRef": "semantic.color.text.secondary"
                 },
                 {

--- a/front/package.json
+++ b/front/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "firebase": "^12.10.0",
+    "lucide-react": "^0.577.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-router-dom": "^7.13.1"

--- a/front/pnpm-lock.yaml
+++ b/front/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       firebase:
         specifier: ^12.10.0
         version: 12.10.0
+      lucide-react:
+        specifier: ^0.577.0
+        version: 0.577.0(react@19.2.4)
       react:
         specifier: ^19.2.4
         version: 19.2.4
@@ -1245,6 +1248,11 @@ packages:
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  lucide-react@0.577.0:
+    resolution: {integrity: sha512-4LjoFv2eEPwYDPg/CUdBJQSDfPyzXCRrVW1X7jrx/trgxnxkHFjnVZINbzvzxjN70dxychOfg+FTYwBiS3pQ5A==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -2784,6 +2792,10 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  lucide-react@0.577.0(react@19.2.4):
+    dependencies:
+      react: 19.2.4
 
   magic-string@0.30.21:
     dependencies:

--- a/front/src/App.tsx
+++ b/front/src/App.tsx
@@ -1,15 +1,11 @@
 /**
  * アプリケーションルートコンポーネント
- * Sprint 1完了時点ではルーティング設定（#5）で置き換え予定
+ * #5でreact-router-domによるルーティングに差し替え予定
  */
+import TimelinePage from './pages/TimelinePage'
+
 function App() {
-  return (
-    <div className="flex min-h-svh items-center justify-center bg-stone-900">
-      <h1 className="font-primary text-3xl font-bold text-stone-50">
-        ほっとSNS
-      </h1>
-    </div>
-  )
+  return <TimelinePage />
 }
 
 export default App

--- a/front/src/App.tsx
+++ b/front/src/App.tsx
@@ -1,10 +1,17 @@
 /**
  * アプリケーションルートコンポーネント
  * #5でreact-router-domによるルーティングに差し替え予定
+ * 暫定: URLパスで表示ページを切り替え
  */
 import TimelinePage from './pages/TimelinePage'
+import UsersPage from './pages/UsersPage'
+import ProfilePage from './pages/ProfilePage'
 
 function App() {
+  const path = window.location.pathname
+
+  if (path.startsWith('/users')) return <UsersPage />
+  if (path.startsWith('/profile')) return <ProfilePage />
   return <TimelinePage />
 }
 

--- a/front/src/index.css
+++ b/front/src/index.css
@@ -1,6 +1,6 @@
 @import "tailwindcss";
 
-/* デザイントークン: design-tokens.json から変換 */
+/* デザイントークン: design-tokens.json v2 から変換 */
 @theme {
   /* カラー: Stone系（ダーク背景） */
   --color-stone-50: #FAFAF9;
@@ -21,9 +21,21 @@
   --color-honey-muted: #D4A57426;
   --color-honey-glow: #D4A57410;
 
+  /* カラー: Glass系（グラスモーフィズム） */
+  --color-glass-sidebar: #FFFFFF08;
+  --color-glass-card: #FFFFFF0D;
+  --color-glass-border: #FFFFFF0F;
+
+  /* カラー: ナビゲーション */
+  --color-nav-active: #33302C;
+
+  /* カラー: ボーダー */
+  --color-border-subtle: #2E2A25;
+
   /* カラー: 危険・情報 */
   --color-danger-300: #F0A0A0;
   --color-danger-muted: #F0A0A026;
+  --color-blue-muted: #5B9BD526;
 
   /* フォント */
   --font-primary: "Noto Sans JP", system-ui, sans-serif;

--- a/front/src/pages/ProfilePage.tsx
+++ b/front/src/pages/ProfilePage.tsx
@@ -1,0 +1,172 @@
+/**
+ * プロフィール画面
+ * ユーザー情報＋フォロー数/フォロワー数＋投稿一覧を表示。
+ * このファイルは静的UI骨格（ロジックなし）。#4でコンポーネント分割する。
+ */
+
+/** ダミープロフィールデータ（Sprint 2でFirestore接続に差し替え） */
+const DUMMY_PROFILE = {
+  id: '2',
+  name: 'ひなた',
+  handle: '@hinata',
+  bio: 'カフェ巡りと写真が好き。日々の小さな幸せを見つけるのが得意。',
+  followingCount: 12,
+  followersCount: 8,
+  isFollowing: true,
+}
+
+const DUMMY_POSTS = [
+  {
+    id: '1',
+    authorName: 'ひなた',
+    handle: '@hinata',
+    content: '今日は早めに帰れたので、お気に入りのカフェでゆっくり読書中。窓の外の雨音が心地いい。',
+    timestamp: '2時間前',
+  },
+  {
+    id: '4',
+    authorName: 'ひなた',
+    handle: '@hinata',
+    content: '朝の散歩で見つけた花がとてもきれいだった。春はもうすぐそこ。',
+    timestamp: '1日前',
+  },
+]
+
+export default function ProfilePage() {
+  return (
+    <div className="flex min-h-svh">
+      {/* サイドバー */}
+      <nav
+        role="navigation"
+        className="sticky top-0 flex h-svh w-[280px] shrink-0 flex-col border-r border-stone-800 bg-stone-800/50 p-8 backdrop-blur-[16px]"
+      >
+        <div className="mb-8 text-xl font-bold text-stone-50">ほっとSNS</div>
+
+        <ul className="flex flex-col gap-1">
+          <li>
+            <a
+              href="/"
+              className="flex items-center gap-3 rounded-md px-4 py-3 text-base text-stone-400 hover:bg-stone-800"
+            >
+              <span>🏠</span>
+              タイムライン
+            </a>
+          </li>
+          <li>
+            <a
+              href="/users"
+              className="flex items-center gap-3 rounded-md px-4 py-3 text-base text-stone-400 hover:bg-stone-800"
+            >
+              <span>👥</span>
+              ユーザー一覧
+            </a>
+          </li>
+          <li>
+            <a
+              href="/profile/1"
+              className="flex items-center gap-3 rounded-md bg-stone-800 px-4 py-3 text-base font-medium text-stone-50"
+            >
+              <span className="text-sage-300">👤</span>
+              プロフィール
+            </a>
+          </li>
+        </ul>
+
+        <div className="mt-auto flex items-center gap-3 rounded-lg border border-stone-700 p-3">
+          <div className="flex h-10 w-10 items-center justify-center rounded-full bg-sage-300 text-sm font-bold text-stone-900">
+            さ
+          </div>
+          <div>
+            <div className="text-sm font-medium text-stone-50">さくら</div>
+            <div className="text-xs text-stone-400">@sakura</div>
+          </div>
+        </div>
+      </nav>
+
+      {/* メインコンテンツ */}
+      <main className="flex flex-1 flex-col gap-6 p-8">
+        <div
+          className="pointer-events-none fixed inset-0"
+          style={{
+            background:
+              'radial-gradient(ellipse at 55% 30%, rgba(212,165,116,0.06) 0%, transparent 100%)',
+          }}
+        />
+
+        {/* プロフィールヘッダー */}
+        <header
+          role="banner"
+          className="relative flex flex-col gap-5 rounded-lg border border-stone-800 bg-white/5 p-6 shadow-card backdrop-blur-[12px]"
+        >
+          <div className="flex items-start gap-5">
+            <div className="flex h-16 w-16 shrink-0 items-center justify-center rounded-full bg-stone-700 text-xl font-bold text-stone-50">
+              {DUMMY_PROFILE.name[0]}
+            </div>
+            <div className="flex flex-1 flex-col gap-1">
+              <h1 className="text-2xl font-bold text-stone-50">
+                {DUMMY_PROFILE.name}
+              </h1>
+              <span className="text-sm text-stone-500">
+                {DUMMY_PROFILE.handle}
+              </span>
+              <p className="mt-2 text-base leading-relaxed text-stone-400">
+                {DUMMY_PROFILE.bio}
+              </p>
+            </div>
+            <button
+              type="button"
+              className="rounded-full border border-sage-300 px-4 py-1.5 text-sm text-sage-300 transition-colors hover:border-danger-300 hover:text-danger-300"
+            >
+              フォロー中
+            </button>
+          </div>
+
+          {/* フォロー数/フォロワー数 */}
+          <div className="flex gap-6">
+            <div className="flex items-center gap-1">
+              <span className="text-sm font-semibold text-stone-50">
+                {DUMMY_PROFILE.followingCount}
+              </span>
+              <span className="text-sm text-stone-500">フォロー中</span>
+            </div>
+            <div className="flex items-center gap-1">
+              <span className="text-sm font-semibold text-stone-50">
+                {DUMMY_PROFILE.followersCount}
+              </span>
+              <span className="text-sm text-stone-500">フォロワー</span>
+            </div>
+          </div>
+        </header>
+
+        {/* 投稿セクション */}
+        <div className="relative flex flex-col gap-3">
+          <h2 className="text-lg text-stone-400">投稿</h2>
+          {DUMMY_POSTS.map((post) => (
+            <article
+              key={post.id}
+              className="flex gap-3 rounded-lg border border-stone-800 bg-white/5 p-5 shadow-card backdrop-blur-[12px]"
+            >
+              <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-stone-700 text-sm font-medium text-stone-50">
+                {post.authorName[0]}
+              </div>
+              <div className="flex flex-col gap-1">
+                <div className="flex items-center gap-2">
+                  <span className="text-sm font-semibold text-stone-50">
+                    {post.authorName}
+                  </span>
+                  <span className="text-sm text-stone-500">{post.handle}</span>
+                  <span className="text-xs text-stone-500">
+                    · {post.timestamp}
+                  </span>
+                </div>
+                <p className="text-base leading-relaxed text-stone-50">
+                  {post.content}
+                </p>
+              </div>
+            </article>
+          ))}
+        </div>
+      </main>
+    </div>
+  )
+}

--- a/front/src/pages/ProfilePage.tsx
+++ b/front/src/pages/ProfilePage.tsx
@@ -1,161 +1,186 @@
 /**
  * プロフィール画面
  * ユーザー情報＋フォロー数/フォロワー数＋投稿一覧を表示。
- * このファイルは静的UI骨格（ロジックなし）。#4でコンポーネント分割する。
+ * 静的UI骨格（ロジックなし）。#4でコンポーネント分割する。
+ * @see doc/input/design/design_context.json ProfilePage
  */
+import { Leaf, Newspaper, Users, User } from 'lucide-react'
 
 /** ダミープロフィールデータ（Sprint 2でFirestore接続に差し替え） */
 const DUMMY_PROFILE = {
-  id: '2',
-  name: 'ひなた',
-  handle: '@hinata',
-  bio: 'カフェ巡りと写真が好き。日々の小さな幸せを見つけるのが得意。',
+  name: 'さくら',
+  handle: '@sakura',
+  bio: 'お茶と読書が好き。静かな夜のひとときを大切にしています。',
   followingCount: 12,
   followersCount: 8,
-  isFollowing: true,
+  avatarColor: 'bg-honey-muted',
 }
 
 const DUMMY_POSTS = [
   {
     id: '1',
-    authorName: 'ひなた',
-    handle: '@hinata',
-    content: '今日は早めに帰れたので、お気に入りのカフェでゆっくり読書中。窓の外の雨音が心地いい。',
+    authorName: 'さくら',
+    handle: '@sakura',
+    content:
+      '今日も一日お疲れさまでした。夜風が気持ちいい季節になりましたね。窓を開けて深呼吸すると、少しだけ心が軽くなる気がします。',
     timestamp: '2時間前',
+    avatarColor: 'bg-honey-muted',
   },
   {
-    id: '4',
-    authorName: 'ひなた',
-    handle: '@hinata',
-    content: '朝の散歩で見つけた花がとてもきれいだった。春はもうすぐそこ。',
+    id: '2',
+    authorName: 'さくら',
+    handle: '@sakura',
+    content:
+      '雨上がりの空がきれいだった。虹は見えなかったけど、雲の隙間から差す光がとても穏やかで。',
     timestamp: '1日前',
+    avatarColor: 'bg-honey-muted',
   },
 ]
 
 export default function ProfilePage() {
   return (
-    <div className="flex min-h-svh">
+    <div
+      className="flex min-h-svh bg-stone-900"
+      style={{
+        background:
+          '#1C1917 radial-gradient(ellipse at 55% 30%, rgba(212,165,116,0.06) 0%, transparent 100%)',
+      }}
+    >
       {/* サイドバー */}
       <nav
         role="navigation"
-        className="sticky top-0 flex h-svh w-[280px] shrink-0 flex-col border-r border-stone-800 bg-stone-800/50 p-8 backdrop-blur-[16px]"
+        className="sticky top-0 flex h-svh w-[280px] shrink-0 flex-col border-r border-glass-border backdrop-blur-[16px]"
+        style={{
+          background:
+            '#FFFFFF08 linear-gradient(180deg, rgba(212,165,116,0.03) 0%, #1C1917 100%)',
+        }}
       >
-        <div className="mb-8 text-xl font-bold text-stone-50">ほっとSNS</div>
-
-        <ul className="flex flex-col gap-1">
-          <li>
-            <a
-              href="/"
-              className="flex items-center gap-3 rounded-md px-4 py-3 text-base text-stone-400 hover:bg-stone-800"
-            >
-              <span>🏠</span>
-              タイムライン
-            </a>
-          </li>
-          <li>
-            <a
-              href="/users"
-              className="flex items-center gap-3 rounded-md px-4 py-3 text-base text-stone-400 hover:bg-stone-800"
-            >
-              <span>👥</span>
-              ユーザー一覧
-            </a>
-          </li>
-          <li>
-            <a
-              href="/profile/1"
-              className="flex items-center gap-3 rounded-md bg-stone-800 px-4 py-3 text-base font-medium text-stone-50"
-            >
-              <span className="text-sage-300">👤</span>
-              プロフィール
-            </a>
-          </li>
-        </ul>
-
-        <div className="mt-auto flex items-center gap-3 rounded-lg border border-stone-700 p-3">
-          <div className="flex h-10 w-10 items-center justify-center rounded-full bg-sage-300 text-sm font-bold text-stone-900">
-            さ
+        <div className="flex flex-1 flex-col px-6 py-8">
+          <div className="flex items-center gap-3 pb-6">
+            <Leaf className="h-7 w-7 text-sage-300" />
+            <span className="text-xl font-bold text-stone-50">ほっとSNS</span>
           </div>
-          <div>
-            <div className="text-sm font-medium text-stone-50">さくら</div>
-            <div className="text-xs text-stone-400">@sakura</div>
+
+          <ul className="flex flex-col gap-1">
+            <li>
+              <a
+                href="/"
+                className="flex items-center gap-3 rounded-md px-4 py-3 text-base font-medium text-stone-400"
+              >
+                <Newspaper className="h-5 w-5 text-stone-400" />
+                タイムライン
+              </a>
+            </li>
+            <li>
+              <a
+                href="/users"
+                className="flex items-center gap-3 rounded-md px-4 py-3 text-base font-medium text-stone-400"
+              >
+                <Users className="h-5 w-5 text-stone-400" />
+                ユーザー一覧
+              </a>
+            </li>
+            <li>
+              <a
+                href="/profile/1"
+                className="flex items-center gap-3 rounded-md bg-nav-active px-4 py-3 text-base font-semibold text-stone-50"
+              >
+                <User className="h-5 w-5 text-sage-300" />
+                プロフィール
+              </a>
+            </li>
+          </ul>
+
+          <div className="flex-1" />
+
+          <div className="flex items-center gap-3 border-t border-border-subtle pt-4">
+            <div className="h-10 w-10 rounded-full bg-sage-muted" />
+            <div className="flex flex-col gap-0.5">
+              <span className="text-md font-semibold text-stone-50">
+                さくら
+              </span>
+              <span className="text-xs text-stone-500">@sakura</span>
+            </div>
           </div>
         </div>
       </nav>
 
-      {/* メインコンテンツ */}
-      <main className="flex flex-1 flex-col gap-6 p-8">
-        <div
-          className="pointer-events-none fixed inset-0"
-          style={{
-            background:
-              'radial-gradient(ellipse at 55% 30%, rgba(212,165,116,0.06) 0%, transparent 100%)',
-          }}
-        />
-
-        {/* プロフィールヘッダー */}
+      {/* メインコンテンツ: padding 32px 48px, gap 24px */}
+      <main className="flex flex-1 flex-col gap-6 overflow-hidden px-12 py-8">
+        {/* プロフィールヘッダー: padding 24px 24px 20px 24px, gap 16px */}
         <header
           role="banner"
-          className="relative flex flex-col gap-5 rounded-lg border border-stone-800 bg-white/5 p-6 shadow-card backdrop-blur-[12px]"
+          className="flex flex-col gap-4 rounded-lg border border-glass-border bg-glass-card pb-5 pl-6 pr-6 pt-6 backdrop-blur-[12px]"
         >
-          <div className="flex items-start gap-5">
-            <div className="flex h-16 w-16 shrink-0 items-center justify-center rounded-full bg-stone-700 text-xl font-bold text-stone-50">
-              {DUMMY_PROFILE.name[0]}
-            </div>
-            <div className="flex flex-1 flex-col gap-1">
-              <h1 className="text-2xl font-bold text-stone-50">
+          {/* 上段: avatar + info + followButton */}
+          <div className="flex items-center gap-4">
+            <div
+              className={`h-16 w-16 shrink-0 rounded-full ${DUMMY_PROFILE.avatarColor}`}
+            />
+            <div className="flex flex-1 flex-col gap-0.5">
+              <h1 className="text-xl font-bold text-stone-50">
                 {DUMMY_PROFILE.name}
               </h1>
               <span className="text-sm text-stone-500">
                 {DUMMY_PROFILE.handle}
               </span>
-              <p className="mt-2 text-base leading-relaxed text-stone-400">
-                {DUMMY_PROFILE.bio}
-              </p>
             </div>
+            {/* フォローボタン: outline, gradient stroke */}
             <button
               type="button"
-              className="rounded-full border border-sage-300 px-4 py-1.5 text-sm text-sage-300 transition-colors hover:border-danger-300 hover:text-danger-300"
+              className="rounded-full px-6 py-2.5 text-md font-semibold text-sage-300 shadow-glow-accent-subtle"
+              style={{
+                border: '1px solid transparent',
+                backgroundImage:
+                  'linear-gradient(#1C1917, #1C1917), linear-gradient(135deg, #8BAA7F 0%, #A8D4A0 100%)',
+                backgroundOrigin: 'border-box',
+                backgroundClip: 'padding-box, border-box',
+              }}
             >
               フォロー中
             </button>
           </div>
 
-          {/* フォロー数/フォロワー数 */}
-          <div className="flex gap-6">
-            <div className="flex items-center gap-1">
-              <span className="text-sm font-semibold text-stone-50">
+          {/* bio */}
+          <p className="text-md leading-relaxed text-stone-400">
+            {DUMMY_PROFILE.bio}
+          </p>
+
+          {/* フォロー数/フォロワー数: border-top #2E2A25, gap 32px */}
+          <div className="flex gap-8 border-t border-border-subtle pt-3">
+            <div className="flex items-center gap-1.5">
+              <span className="text-lg font-bold text-stone-50">
                 {DUMMY_PROFILE.followingCount}
               </span>
-              <span className="text-sm text-stone-500">フォロー中</span>
+              <span className="text-md text-stone-400">フォロー中</span>
             </div>
-            <div className="flex items-center gap-1">
-              <span className="text-sm font-semibold text-stone-50">
+            <div className="flex items-center gap-1.5">
+              <span className="text-lg font-bold text-stone-50">
                 {DUMMY_PROFILE.followersCount}
               </span>
-              <span className="text-sm text-stone-500">フォロワー</span>
+              <span className="text-md text-stone-400">フォロワー</span>
             </div>
           </div>
         </header>
 
-        {/* 投稿セクション */}
-        <div className="relative flex flex-col gap-3">
-          <h2 className="text-lg text-stone-400">投稿</h2>
+        {/* 投稿セクション: gap 12px */}
+        <div className="flex flex-col gap-3">
+          <h2 className="text-lg font-semibold text-stone-400">投稿</h2>
           {DUMMY_POSTS.map((post) => (
             <article
               key={post.id}
-              className="flex gap-3 rounded-lg border border-stone-800 bg-white/5 p-5 shadow-card backdrop-blur-[12px]"
+              className="flex gap-3 rounded-lg border border-glass-border bg-glass-card p-5 backdrop-blur-[12px]"
             >
-              <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-stone-700 text-sm font-medium text-stone-50">
-                {post.authorName[0]}
-              </div>
-              <div className="flex flex-col gap-1">
+              <div
+                className={`h-10 w-10 shrink-0 rounded-full ${post.avatarColor}`}
+              />
+              <div className="flex flex-col gap-2">
                 <div className="flex items-center gap-2">
-                  <span className="text-sm font-semibold text-stone-50">
+                  <span className="text-base font-semibold text-stone-50">
                     {post.authorName}
                   </span>
                   <span className="text-sm text-stone-500">{post.handle}</span>
-                  <span className="text-xs text-stone-500">
+                  <span className="text-sm text-stone-500">
                     · {post.timestamp}
                   </span>
                 </div>

--- a/front/src/pages/TimelinePage.tsx
+++ b/front/src/pages/TimelinePage.tsx
@@ -1,0 +1,157 @@
+/**
+ * タイムライン画面
+ * フォロー中＋自分の投稿をcreatedAt降順で表示。投稿の作成が可能。
+ * このファイルは静的UI骨格（ロジックなし）。#4でコンポーネント分割する。
+ */
+
+/** ダミー投稿データ（Sprint 2でFirestore接続に差し替え） */
+const DUMMY_POSTS = [
+  {
+    id: '1',
+    authorName: 'ひなた',
+    handle: '@hinata',
+    content: '今日は早めに帰れたので、お気に入りのカフェでゆっくり読書中。窓の外の雨音が心地いい。',
+    timestamp: '2時間前',
+  },
+  {
+    id: '2',
+    authorName: 'さくら',
+    handle: '@sakura',
+    content: '新しいお茶を見つけました。ほうじ茶ラテ、寒い夜にぴったり。',
+    timestamp: '4時間前',
+  },
+  {
+    id: '3',
+    authorName: 'そら',
+    handle: '@sora',
+    content: '夕焼けがきれいだったので思わず立ち止まってしまった。こういう瞬間を大切にしたい。',
+    timestamp: '6時間前',
+  },
+]
+
+export default function TimelinePage() {
+  return (
+    <div className="flex min-h-svh">
+      {/* サイドバー */}
+      <nav
+        role="navigation"
+        className="sticky top-0 flex h-svh w-[280px] shrink-0 flex-col border-r border-stone-800 bg-stone-800/50 p-8 backdrop-blur-[16px]"
+      >
+        {/* ロゴ */}
+        <div className="mb-8 text-xl font-bold text-stone-50">ほっとSNS</div>
+
+        {/* ナビゲーション */}
+        <ul className="flex flex-col gap-1">
+          <li>
+            <a
+              href="/"
+              className="flex items-center gap-3 rounded-md bg-stone-800 px-4 py-3 text-base font-medium text-stone-50"
+            >
+              <span className="text-sage-300">🏠</span>
+              タイムライン
+            </a>
+          </li>
+          <li>
+            <a
+              href="/users"
+              className="flex items-center gap-3 rounded-md px-4 py-3 text-base text-stone-400 hover:bg-stone-800"
+            >
+              <span>👥</span>
+              ユーザー一覧
+            </a>
+          </li>
+          <li>
+            <a
+              href="/profile/1"
+              className="flex items-center gap-3 rounded-md px-4 py-3 text-base text-stone-400 hover:bg-stone-800"
+            >
+              <span>👤</span>
+              プロフィール
+            </a>
+          </li>
+        </ul>
+
+        {/* 現在のユーザー */}
+        <div className="mt-auto flex items-center gap-3 rounded-lg border border-stone-700 p-3">
+          <div className="flex h-10 w-10 items-center justify-center rounded-full bg-sage-300 text-sm font-bold text-stone-900">
+            さ
+          </div>
+          <div>
+            <div className="text-sm font-medium text-stone-50">さくら</div>
+            <div className="text-xs text-stone-400">@sakura</div>
+          </div>
+        </div>
+      </nav>
+
+      {/* メインコンテンツ */}
+      <main className="flex flex-1 flex-col gap-6 p-8">
+        {/* ページ背景のウォームグロー */}
+        <div
+          className="pointer-events-none fixed inset-0"
+          style={{
+            background:
+              'radial-gradient(ellipse at 55% 30%, rgba(212,165,116,0.06) 0%, transparent 100%)',
+          }}
+        />
+
+        <h1 className="relative text-3xl font-bold text-stone-50">
+          タイムライン
+        </h1>
+
+        {/* コンポーザー */}
+        <form
+          role="form"
+          aria-label="投稿を作成"
+          className="relative flex gap-4 rounded-lg border border-stone-800 bg-white/5 p-5 shadow-card backdrop-blur-[12px]"
+        >
+          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-sage-300 text-sm font-bold text-stone-900">
+            さ
+          </div>
+          <div className="flex flex-1 flex-col gap-3">
+            <textarea
+              placeholder="いまどうしてる？"
+              className="min-h-[80px] resize-none bg-transparent text-base text-stone-50 placeholder:text-stone-500 focus:outline-none"
+            />
+            <div className="flex items-center justify-between">
+              <span className="text-xs text-stone-500">0/140</span>
+              <button
+                type="button"
+                className="rounded-full bg-gradient-to-br from-sage-300 to-sage-500 px-5 py-2 text-sm font-semibold text-stone-900 shadow-glow-accent transition-shadow hover:shadow-glow-accent"
+              >
+                投稿する
+              </button>
+            </div>
+          </div>
+        </form>
+
+        {/* 投稿フィード */}
+        <div className="relative flex flex-col gap-3">
+          {DUMMY_POSTS.map((post) => (
+            <article
+              key={post.id}
+              className="flex gap-3 rounded-lg border border-stone-800 bg-white/5 p-5 shadow-card backdrop-blur-[12px]"
+            >
+              <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-stone-700 text-sm font-medium text-stone-50">
+                {post.authorName[0]}
+              </div>
+              <div className="flex flex-col gap-1">
+                <div className="flex items-center gap-2">
+                  <span className="text-sm font-semibold text-stone-50">
+                    {post.authorName}
+                  </span>
+                  <span className="text-sm text-stone-500">{post.handle}</span>
+                  <span className="text-xs text-stone-500">
+                    · {post.timestamp}
+                  </span>
+                </div>
+                <p className="text-base leading-relaxed text-stone-50">
+                  {post.content}
+                </p>
+              </div>
+            </article>
+          ))}
+        </div>
+      </main>
+    </div>
+  )
+}

--- a/front/src/pages/TimelinePage.tsx
+++ b/front/src/pages/TimelinePage.tsx
@@ -1,146 +1,164 @@
 /**
  * タイムライン画面
  * フォロー中＋自分の投稿をcreatedAt降順で表示。投稿の作成が可能。
- * このファイルは静的UI骨格（ロジックなし）。#4でコンポーネント分割する。
+ * 静的UI骨格（ロジックなし）。#4でコンポーネント分割する。
+ * @see doc/input/design/design_context.json TimelinePage
  */
+import { Leaf, Newspaper, Users, User } from 'lucide-react'
 
 /** ダミー投稿データ（Sprint 2でFirestore接続に差し替え） */
 const DUMMY_POSTS = [
   {
     id: '1',
-    authorName: 'ひなた',
-    handle: '@hinata',
-    content: '今日は早めに帰れたので、お気に入りのカフェでゆっくり読書中。窓の外の雨音が心地いい。',
+    authorName: 'さくら',
+    handle: '@sakura',
+    content:
+      '今日も一日お疲れさまでした。夜風が気持ちいい季節になりましたね。窓を開けて深呼吸すると、少しだけ心が軽くなる気がします。',
     timestamp: '2時間前',
+    avatarColor: 'bg-honey-muted',
   },
   {
     id: '2',
-    authorName: 'さくら',
-    handle: '@sakura',
-    content: '新しいお茶を見つけました。ほうじ茶ラテ、寒い夜にぴったり。',
+    authorName: 'はると',
+    handle: '@haruto',
+    content:
+      '近所のカフェで見つけた新しいブレンド、すごく美味しかった。明日も行こうかな。',
     timestamp: '4時間前',
+    avatarColor: 'bg-sage-muted',
   },
   {
     id: '3',
-    authorName: 'そら',
-    handle: '@sora',
-    content: '夕焼けがきれいだったので思わず立ち止まってしまった。こういう瞬間を大切にしたい。',
+    authorName: 'ゆき',
+    handle: '@yuki',
+    content:
+      '読みかけの本をやっと読み終えた。静かな夜に読書するのが最高の贅沢。',
     timestamp: '6時間前',
+    avatarColor: 'bg-danger-muted',
   },
 ]
 
 export default function TimelinePage() {
   return (
-    <div className="flex min-h-svh">
-      {/* サイドバー */}
+    <div
+      className="flex min-h-svh bg-stone-900"
+      style={{
+        background:
+          '#1C1917 radial-gradient(ellipse at 55% 30%, rgba(212,165,116,0.06) 0%, transparent 100%)',
+      }}
+    >
+      {/* サイドバー: glass.sidebar + gradient overlay + backdrop-blur 16px */}
       <nav
         role="navigation"
-        className="sticky top-0 flex h-svh w-[280px] shrink-0 flex-col border-r border-stone-800 bg-stone-800/50 p-8 backdrop-blur-[16px]"
+        className="sticky top-0 flex h-svh w-[280px] shrink-0 flex-col border-r border-glass-border backdrop-blur-[16px]"
+        style={{
+          background:
+            '#FFFFFF08 linear-gradient(180deg, rgba(212,165,116,0.03) 0%, #1C1917 100%)',
+        }}
       >
-        {/* ロゴ */}
-        <div className="mb-8 text-xl font-bold text-stone-50">ほっとSNS</div>
-
-        {/* ナビゲーション */}
-        <ul className="flex flex-col gap-1">
-          <li>
-            <a
-              href="/"
-              className="flex items-center gap-3 rounded-md bg-stone-800 px-4 py-3 text-base font-medium text-stone-50"
-            >
-              <span className="text-sage-300">🏠</span>
-              タイムライン
-            </a>
-          </li>
-          <li>
-            <a
-              href="/users"
-              className="flex items-center gap-3 rounded-md px-4 py-3 text-base text-stone-400 hover:bg-stone-800"
-            >
-              <span>👥</span>
-              ユーザー一覧
-            </a>
-          </li>
-          <li>
-            <a
-              href="/profile/1"
-              className="flex items-center gap-3 rounded-md px-4 py-3 text-base text-stone-400 hover:bg-stone-800"
-            >
-              <span>👤</span>
-              プロフィール
-            </a>
-          </li>
-        </ul>
-
-        {/* 現在のユーザー */}
-        <div className="mt-auto flex items-center gap-3 rounded-lg border border-stone-700 p-3">
-          <div className="flex h-10 w-10 items-center justify-center rounded-full bg-sage-300 text-sm font-bold text-stone-900">
-            さ
+        <div className="flex flex-1 flex-col px-6 py-8">
+          {/* ロゴ: lucide leaf + テキスト */}
+          <div className="flex items-center gap-3 pb-6">
+            <Leaf className="h-7 w-7 text-sage-300" />
+            <span className="text-xl font-bold text-stone-50">ほっとSNS</span>
           </div>
-          <div>
-            <div className="text-sm font-medium text-stone-50">さくら</div>
-            <div className="text-xs text-stone-400">@sakura</div>
+
+          {/* ナビゲーション: gap 4px, cornerRadius 12px, padding 12px 16px */}
+          <ul className="flex flex-col gap-1">
+            <li>
+              <a
+                href="/"
+                className="flex items-center gap-3 rounded-md bg-nav-active px-4 py-3 text-base font-semibold text-stone-50"
+              >
+                <Newspaper className="h-5 w-5 text-sage-300" />
+                タイムライン
+              </a>
+            </li>
+            <li>
+              <a
+                href="/users"
+                className="flex items-center gap-3 rounded-md px-4 py-3 text-base font-medium text-stone-400"
+              >
+                <Users className="h-5 w-5 text-stone-400" />
+                ユーザー一覧
+              </a>
+            </li>
+            <li>
+              <a
+                href="/profile/1"
+                className="flex items-center gap-3 rounded-md px-4 py-3 text-base font-medium text-stone-400"
+              >
+                <User className="h-5 w-5 text-stone-400" />
+                プロフィール
+              </a>
+            </li>
+          </ul>
+
+          {/* スペーサー */}
+          <div className="flex-1" />
+
+          {/* 現在のユーザー: border-top #2E2A25, gap 12px */}
+          <div className="flex items-center gap-3 border-t border-border-subtle pt-4">
+            <div className="h-10 w-10 rounded-full bg-sage-muted" />
+            <div className="flex flex-col gap-0.5">
+              <span className="text-md font-semibold text-stone-50">
+                さくら
+              </span>
+              <span className="text-xs text-stone-500">@sakura</span>
+            </div>
           </div>
         </div>
       </nav>
 
-      {/* メインコンテンツ */}
-      <main className="flex flex-1 flex-col gap-6 p-8">
-        {/* ページ背景のウォームグロー */}
-        <div
-          className="pointer-events-none fixed inset-0"
-          style={{
-            background:
-              'radial-gradient(ellipse at 55% 30%, rgba(212,165,116,0.06) 0%, transparent 100%)',
-          }}
-        />
+      {/* メインコンテンツ: padding 32px 48px, gap 24px, clip */}
+      <main className="flex flex-1 flex-col gap-6 overflow-hidden px-12 py-8">
+        <h1 className="text-3xl font-bold text-stone-50">タイムライン</h1>
 
-        <h1 className="relative text-3xl font-bold text-stone-50">
-          タイムライン
-        </h1>
-
-        {/* コンポーザー */}
+        {/* コンポーザー: vertical, gap 16px, padding 20px, cornerRadius 16px */}
         <form
           role="form"
           aria-label="投稿を作成"
-          className="relative flex gap-4 rounded-lg border border-stone-800 bg-white/5 p-5 shadow-card backdrop-blur-[12px]"
+          className="flex flex-col gap-4 rounded-lg border border-glass-border bg-glass-card p-5 backdrop-blur-[12px]"
         >
-          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-sage-300 text-sm font-bold text-stone-900">
-            さ
-          </div>
-          <div className="flex flex-1 flex-col gap-3">
+          {/* 上段: avatar + input */}
+          <div className="flex gap-3">
+            <div className="h-10 w-10 shrink-0 rounded-full bg-sage-muted" />
             <textarea
               placeholder="いまどうしてる？"
-              className="min-h-[80px] resize-none bg-transparent text-base text-stone-50 placeholder:text-stone-500 focus:outline-none"
+              className="min-h-[60px] flex-1 resize-none bg-transparent text-base leading-relaxed text-stone-50 placeholder:text-stone-500 focus:outline-none"
             />
-            <div className="flex items-center justify-between">
-              <span className="text-xs text-stone-500">0/140</span>
-              <button
-                type="button"
-                className="rounded-full bg-gradient-to-br from-sage-300 to-sage-500 px-5 py-2 text-sm font-semibold text-stone-900 shadow-glow-accent transition-shadow hover:shadow-glow-accent"
-              >
-                投稿する
-              </button>
-            </div>
+          </div>
+          {/* 下段: charCount + button（右寄せ） */}
+          <div className="flex items-center justify-end gap-3">
+            <span className="text-xs text-stone-500">0/140</span>
+            <button
+              type="button"
+              className="rounded-full px-6 py-2.5 text-md font-semibold text-stone-900 shadow-glow-accent"
+              style={{
+                background: 'linear-gradient(135deg, #8BAA7F 0%, #A8D4A0 100%)',
+              }}
+            >
+              投稿する
+            </button>
           </div>
         </form>
 
-        {/* 投稿フィード */}
-        <div className="relative flex flex-col gap-3">
+        {/* 投稿フィード: gap 12px */}
+        <div className="flex flex-col gap-3">
           {DUMMY_POSTS.map((post) => (
             <article
               key={post.id}
-              className="flex gap-3 rounded-lg border border-stone-800 bg-white/5 p-5 shadow-card backdrop-blur-[12px]"
+              className="flex gap-3 rounded-lg border border-glass-border bg-glass-card p-5 backdrop-blur-[12px]"
             >
-              <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-stone-700 text-sm font-medium text-stone-50">
-                {post.authorName[0]}
-              </div>
-              <div className="flex flex-col gap-1">
+              <div
+                className={`h-10 w-10 shrink-0 rounded-full ${post.avatarColor}`}
+              />
+              <div className="flex flex-col gap-2">
                 <div className="flex items-center gap-2">
-                  <span className="text-sm font-semibold text-stone-50">
+                  <span className="text-base font-semibold text-stone-50">
                     {post.authorName}
                   </span>
                   <span className="text-sm text-stone-500">{post.handle}</span>
-                  <span className="text-xs text-stone-500">
+                  <span className="text-sm text-stone-500">
                     · {post.timestamp}
                   </span>
                 </div>

--- a/front/src/pages/UsersPage.tsx
+++ b/front/src/pages/UsersPage.tsx
@@ -1,0 +1,114 @@
+/**
+ * ユーザー一覧画面
+ * 全ユーザーを表示し、フォロー/アンフォローのトグルが可能。
+ * このファイルは静的UI骨格（ロジックなし）。#4でコンポーネント分割する。
+ */
+
+/** ダミーユーザーデータ（Sprint 2でFirestore接続に差し替え） */
+const DUMMY_USERS = [
+  { id: '2', name: 'ひなた', handle: '@hinata', isFollowing: true },
+  { id: '3', name: 'そら', handle: '@sora', isFollowing: false },
+  { id: '4', name: 'あおい', handle: '@aoi', isFollowing: true },
+  { id: '5', name: 'れん', handle: '@ren', isFollowing: false },
+  { id: '6', name: 'みお', handle: '@mio', isFollowing: false },
+]
+
+export default function UsersPage() {
+  return (
+    <div className="flex min-h-svh">
+      {/* サイドバー */}
+      <nav
+        role="navigation"
+        className="sticky top-0 flex h-svh w-[280px] shrink-0 flex-col border-r border-stone-800 bg-stone-800/50 p-8 backdrop-blur-[16px]"
+      >
+        <div className="mb-8 text-xl font-bold text-stone-50">ほっとSNS</div>
+
+        <ul className="flex flex-col gap-1">
+          <li>
+            <a
+              href="/"
+              className="flex items-center gap-3 rounded-md px-4 py-3 text-base text-stone-400 hover:bg-stone-800"
+            >
+              <span>🏠</span>
+              タイムライン
+            </a>
+          </li>
+          <li>
+            <a
+              href="/users"
+              className="flex items-center gap-3 rounded-md bg-stone-800 px-4 py-3 text-base font-medium text-stone-50"
+            >
+              <span className="text-sage-300">👥</span>
+              ユーザー一覧
+            </a>
+          </li>
+          <li>
+            <a
+              href="/profile/1"
+              className="flex items-center gap-3 rounded-md px-4 py-3 text-base text-stone-400 hover:bg-stone-800"
+            >
+              <span>👤</span>
+              プロフィール
+            </a>
+          </li>
+        </ul>
+
+        <div className="mt-auto flex items-center gap-3 rounded-lg border border-stone-700 p-3">
+          <div className="flex h-10 w-10 items-center justify-center rounded-full bg-sage-300 text-sm font-bold text-stone-900">
+            さ
+          </div>
+          <div>
+            <div className="text-sm font-medium text-stone-50">さくら</div>
+            <div className="text-xs text-stone-400">@sakura</div>
+          </div>
+        </div>
+      </nav>
+
+      {/* メインコンテンツ */}
+      <main className="flex flex-1 flex-col gap-6 p-8">
+        <div
+          className="pointer-events-none fixed inset-0"
+          style={{
+            background:
+              'radial-gradient(ellipse at 55% 30%, rgba(212,165,116,0.06) 0%, transparent 100%)',
+          }}
+        />
+
+        <h1 className="relative text-3xl font-bold text-stone-50">
+          ユーザー一覧
+        </h1>
+
+        {/* ユーザーリスト */}
+        <div className="relative flex flex-col gap-3">
+          {DUMMY_USERS.map((user) => (
+            <article
+              key={user.id}
+              className="flex items-center gap-4 rounded-lg border border-stone-800 bg-white/5 p-5 shadow-card backdrop-blur-[12px]"
+            >
+              <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-stone-700 text-base font-medium text-stone-50">
+                {user.name[0]}
+              </div>
+              <div className="flex flex-1 flex-col">
+                <span className="text-sm font-semibold text-stone-50">
+                  {user.name}
+                </span>
+                <span className="text-sm text-stone-500">{user.handle}</span>
+              </div>
+              {/* フォローボタン（viewerId=1の自分は含まれていない） */}
+              <button
+                type="button"
+                className={
+                  user.isFollowing
+                    ? 'rounded-full border border-sage-300 px-4 py-1.5 text-sm text-sage-300 transition-colors hover:border-danger-300 hover:text-danger-300'
+                    : 'rounded-full bg-gradient-to-br from-sage-300 to-sage-500 px-4 py-1.5 text-sm font-semibold text-stone-900 shadow-glow-accent-subtle'
+                }
+              >
+                {user.isFollowing ? 'フォロー中' : 'フォロー'}
+              </button>
+            </article>
+          ))}
+        </div>
+      </main>
+    </div>
+  )
+}

--- a/front/src/pages/UsersPage.tsx
+++ b/front/src/pages/UsersPage.tsx
@@ -1,110 +1,167 @@
 /**
  * ユーザー一覧画面
  * 全ユーザーを表示し、フォロー/アンフォローのトグルが可能。
- * このファイルは静的UI骨格（ロジックなし）。#4でコンポーネント分割する。
+ * 静的UI骨格（ロジックなし）。#4でコンポーネント分割する。
+ * @see doc/input/design/design_context.json UsersPage
  */
+import { Leaf, Newspaper, Users, User } from 'lucide-react'
 
 /** ダミーユーザーデータ（Sprint 2でFirestore接続に差し替え） */
 const DUMMY_USERS = [
-  { id: '2', name: 'ひなた', handle: '@hinata', isFollowing: true },
-  { id: '3', name: 'そら', handle: '@sora', isFollowing: false },
-  { id: '4', name: 'あおい', handle: '@aoi', isFollowing: true },
-  { id: '5', name: 'れん', handle: '@ren', isFollowing: false },
-  { id: '6', name: 'みお', handle: '@mio', isFollowing: false },
+  {
+    id: '1',
+    name: 'さくら',
+    handle: '@sakura',
+    isFollowing: true,
+    avatarColor: 'bg-honey-muted',
+  },
+  {
+    id: '2',
+    name: 'はると',
+    handle: '@haruto',
+    isFollowing: false,
+    avatarColor: 'bg-sage-muted',
+  },
+  {
+    id: '3',
+    name: 'ゆき',
+    handle: '@yuki',
+    isFollowing: true,
+    avatarColor: 'bg-danger-muted',
+  },
+  {
+    id: '4',
+    name: 'りく',
+    handle: '@riku',
+    isFollowing: false,
+    avatarColor: 'bg-honey-muted',
+  },
+  {
+    id: '5',
+    name: 'あおい',
+    handle: '@aoi',
+    isFollowing: false,
+    avatarColor: 'bg-blue-muted',
+  },
 ]
 
 export default function UsersPage() {
   return (
-    <div className="flex min-h-svh">
+    <div
+      className="flex min-h-svh bg-stone-900"
+      style={{
+        background:
+          '#1C1917 radial-gradient(ellipse at 55% 30%, rgba(212,165,116,0.06) 0%, transparent 100%)',
+      }}
+    >
       {/* サイドバー */}
       <nav
         role="navigation"
-        className="sticky top-0 flex h-svh w-[280px] shrink-0 flex-col border-r border-stone-800 bg-stone-800/50 p-8 backdrop-blur-[16px]"
+        className="sticky top-0 flex h-svh w-[280px] shrink-0 flex-col border-r border-glass-border backdrop-blur-[16px]"
+        style={{
+          background:
+            '#FFFFFF08 linear-gradient(180deg, rgba(212,165,116,0.03) 0%, #1C1917 100%)',
+        }}
       >
-        <div className="mb-8 text-xl font-bold text-stone-50">ほっとSNS</div>
-
-        <ul className="flex flex-col gap-1">
-          <li>
-            <a
-              href="/"
-              className="flex items-center gap-3 rounded-md px-4 py-3 text-base text-stone-400 hover:bg-stone-800"
-            >
-              <span>🏠</span>
-              タイムライン
-            </a>
-          </li>
-          <li>
-            <a
-              href="/users"
-              className="flex items-center gap-3 rounded-md bg-stone-800 px-4 py-3 text-base font-medium text-stone-50"
-            >
-              <span className="text-sage-300">👥</span>
-              ユーザー一覧
-            </a>
-          </li>
-          <li>
-            <a
-              href="/profile/1"
-              className="flex items-center gap-3 rounded-md px-4 py-3 text-base text-stone-400 hover:bg-stone-800"
-            >
-              <span>👤</span>
-              プロフィール
-            </a>
-          </li>
-        </ul>
-
-        <div className="mt-auto flex items-center gap-3 rounded-lg border border-stone-700 p-3">
-          <div className="flex h-10 w-10 items-center justify-center rounded-full bg-sage-300 text-sm font-bold text-stone-900">
-            さ
+        <div className="flex flex-1 flex-col px-6 py-8">
+          <div className="flex items-center gap-3 pb-6">
+            <Leaf className="h-7 w-7 text-sage-300" />
+            <span className="text-xl font-bold text-stone-50">ほっとSNS</span>
           </div>
-          <div>
-            <div className="text-sm font-medium text-stone-50">さくら</div>
-            <div className="text-xs text-stone-400">@sakura</div>
+
+          <ul className="flex flex-col gap-1">
+            <li>
+              <a
+                href="/"
+                className="flex items-center gap-3 rounded-md px-4 py-3 text-base font-medium text-stone-400"
+              >
+                <Newspaper className="h-5 w-5 text-stone-400" />
+                タイムライン
+              </a>
+            </li>
+            <li>
+              <a
+                href="/users"
+                className="flex items-center gap-3 rounded-md bg-nav-active px-4 py-3 text-base font-semibold text-stone-50"
+              >
+                <Users className="h-5 w-5 text-sage-300" />
+                ユーザー一覧
+              </a>
+            </li>
+            <li>
+              <a
+                href="/profile/1"
+                className="flex items-center gap-3 rounded-md px-4 py-3 text-base font-medium text-stone-400"
+              >
+                <User className="h-5 w-5 text-stone-400" />
+                プロフィール
+              </a>
+            </li>
+          </ul>
+
+          <div className="flex-1" />
+
+          <div className="flex items-center gap-3 border-t border-border-subtle pt-4">
+            <div className="h-10 w-10 rounded-full bg-sage-muted" />
+            <div className="flex flex-col gap-0.5">
+              <span className="text-md font-semibold text-stone-50">
+                さくら
+              </span>
+              <span className="text-xs text-stone-500">@sakura</span>
+            </div>
           </div>
         </div>
       </nav>
 
-      {/* メインコンテンツ */}
-      <main className="flex flex-1 flex-col gap-6 p-8">
-        <div
-          className="pointer-events-none fixed inset-0"
-          style={{
-            background:
-              'radial-gradient(ellipse at 55% 30%, rgba(212,165,116,0.06) 0%, transparent 100%)',
-          }}
-        />
+      {/* メインコンテンツ: padding 32px 48px, gap 24px */}
+      <main className="flex flex-1 flex-col gap-6 overflow-hidden px-12 py-8">
+        <h1 className="text-3xl font-bold text-stone-50">ユーザー一覧</h1>
 
-        <h1 className="relative text-3xl font-bold text-stone-50">
-          ユーザー一覧
-        </h1>
-
-        {/* ユーザーリスト */}
-        <div className="relative flex flex-col gap-3">
+        {/* ユーザーリスト: gap 12px */}
+        <div className="flex flex-col gap-3">
           {DUMMY_USERS.map((user) => (
             <article
               key={user.id}
-              className="flex items-center gap-4 rounded-lg border border-stone-800 bg-white/5 p-5 shadow-card backdrop-blur-[12px]"
+              className="flex items-center gap-4 rounded-lg border border-glass-border bg-glass-card p-5 backdrop-blur-[12px]"
             >
-              <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-stone-700 text-base font-medium text-stone-50">
-                {user.name[0]}
-              </div>
-              <div className="flex flex-1 flex-col">
-                <span className="text-sm font-semibold text-stone-50">
+              {/* アバター: 48px ellipse */}
+              <div
+                className={`h-12 w-12 shrink-0 rounded-full ${user.avatarColor}`}
+              />
+              {/* ユーザー情報: gap 4px */}
+              <div className="flex flex-1 flex-col gap-1">
+                <span className="text-base font-semibold text-stone-50">
                   {user.name}
                 </span>
                 <span className="text-sm text-stone-500">{user.handle}</span>
               </div>
-              {/* フォローボタン（viewerId=1の自分は含まれていない） */}
-              <button
-                type="button"
-                className={
-                  user.isFollowing
-                    ? 'rounded-full border border-sage-300 px-4 py-1.5 text-sm text-sage-300 transition-colors hover:border-danger-300 hover:text-danger-300'
-                    : 'rounded-full bg-gradient-to-br from-sage-300 to-sage-500 px-4 py-1.5 text-sm font-semibold text-stone-900 shadow-glow-accent-subtle'
-                }
-              >
-                {user.isFollowing ? 'フォロー中' : 'フォロー'}
-              </button>
+              {/* フォローボタン: outline=gradient stroke, primary=gradient fill */}
+              {user.isFollowing ? (
+                <button
+                  type="button"
+                  className="rounded-full bg-transparent px-5 py-2 text-sm font-semibold text-sage-300 shadow-glow-accent-subtle"
+                  style={{
+                    border: '1px solid transparent',
+                    backgroundImage:
+                      'linear-gradient(#1C1917, #1C1917), linear-gradient(135deg, #8BAA7F 0%, #A8D4A0 100%)',
+                    backgroundOrigin: 'border-box',
+                    backgroundClip: 'padding-box, border-box',
+                  }}
+                >
+                  フォロー中
+                </button>
+              ) : (
+                <button
+                  type="button"
+                  className="rounded-full px-5 py-2 text-sm font-semibold text-stone-900 shadow-glow-accent"
+                  style={{
+                    background:
+                      'linear-gradient(135deg, #8BAA7F 0%, #A8D4A0 100%)',
+                  }}
+                >
+                  フォロー
+                </button>
+              )}
             </article>
           ))}
         </div>


### PR DESCRIPTION
## Summary
- design-tokens.json / design_context.json / copy.json からTimelinePage / UsersPage / ProfilePageの静的JSXを生成
- グラスモーフィズム（backdrop-blur + bg-white/5 + 薄い白ボーダー）適用
- ウォームグロー（radial-gradient）をページ背景に配置
- ダミーデータで表示のみ（ロジックなし、#4でコンポーネント分割予定）

## Test plan
- [x] `pnpm lint` PASS
- [x] `pnpm build` PASS
- [ ] `pnpm dev` でブラウザ表示確認（Pencilデザインとの目視比較）

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)