### PR TITLE
feat: UI骨格からコンポーネント分割（7コンポーネント）

### DIFF
--- a/front/src/components/layout/Sidebar.tsx
+++ b/front/src/components/layout/Sidebar.tsx
@@ -1,0 +1,64 @@
+/**
+ * サイドバーコンポーネント
+ * ロゴ・ナビゲーション・現在ユーザー情報を含む共通コンポーネント
+ * @see doc/input/design/components.json Sidebar
+ */
+import { Leaf } from 'lucide-react'
+import { NavItem, type NavItemProps } from '../navigation/NavItem'
+
+/** ナビゲーション定義 */
+const NAV_ITEMS: NavItemProps[] = [
+  { icon: 'newspaper', label: 'タイムライン', href: '/' },
+  { icon: 'users', label: 'ユーザー一覧', href: '/users' },
+  { icon: 'user', label: 'プロフィール', href: '/profile/1' },
+]
+
+interface SidebarProps {
+  /** 現在のアクティブなパス */
+  activePath: string
+}
+
+export function Sidebar({ activePath }: SidebarProps) {
+  return (
+    <nav
+      role="navigation"
+      className="sticky top-0 flex h-svh w-[280px] shrink-0 flex-col border-r border-glass-border backdrop-blur-[16px]"
+      style={{
+        background:
+          '#FFFFFF08 linear-gradient(180deg, rgba(212,165,116,0.03) 0%, #1C1917 100%)',
+      }}
+    >
+      <div className="flex flex-1 flex-col px-6 py-8">
+        {/* ロゴ: lucide leaf + テキスト, gap 12px, paddingBottom 24px */}
+        <div className="flex items-center gap-3 pb-6">
+          <Leaf className="h-7 w-7 text-sage-300" />
+          <span className="text-xl font-bold text-stone-50">ほっとSNS</span>
+        </div>
+
+        {/* ナビゲーション: gap 4px */}
+        <ul className="flex flex-col gap-1">
+          {NAV_ITEMS.map((item) => (
+            <li key={item.href}>
+              <NavItem
+                {...item}
+                state={activePath === item.href ? 'active' : 'default'}
+              />
+            </li>
+          ))}
+        </ul>
+
+        {/* スペーサー */}
+        <div className="flex-1" />
+
+        {/* 現在のユーザー: border-top #2E2A25, gap 12px, paddingTop 16px */}
+        <div className="flex items-center gap-3 border-t border-border-subtle pt-4">
+          <div className="h-10 w-10 rounded-full bg-sage-muted" />
+          <div className="flex flex-col gap-0.5">
+            <span className="text-md font-semibold text-stone-50">さくら</span>
+            <span className="text-xs text-stone-500">@sakura</span>
+          </div>
+        </div>
+      </div>
+    </nav>
+  )
+}

--- a/front/src/components/navigation/NavItem.tsx
+++ b/front/src/components/navigation/NavItem.tsx
@@ -1,0 +1,51 @@
+/**
+ * ナビゲーション項目コンポーネント
+ * Lucideアイコン＋ラベル。state: default/active
+ * @see doc/input/design/components.json NavItem
+ */
+import { Newspaper, Users, User, type LucideIcon } from 'lucide-react'
+
+const ICON_MAP: Record<string, LucideIcon> = {
+  newspaper: Newspaper,
+  users: Users,
+  user: User,
+}
+
+export interface NavItemProps {
+  /** lucideアイコン名 */
+  icon: string
+  /** ラベルテキスト */
+  label: string
+  /** 遷移先パス */
+  href: string
+  /** 表示状態 */
+  state?: 'default' | 'active'
+}
+
+export function NavItem({
+  icon,
+  label,
+  href,
+  state = 'default',
+}: NavItemProps) {
+  const Icon = ICON_MAP[icon]
+  const isActive = state === 'active'
+
+  return (
+    <a
+      href={href}
+      className={`flex items-center gap-3 rounded-md px-4 py-3 text-base ${
+        isActive
+          ? 'bg-nav-active font-semibold text-stone-50'
+          : 'font-medium text-stone-400'
+      }`}
+    >
+      {Icon && (
+        <Icon
+          className={`h-5 w-5 ${isActive ? 'text-sage-300' : 'text-stone-400'}`}
+        />
+      )}
+      {label}
+    </a>
+  )
+}

--- a/front/src/components/post/Composer.tsx
+++ b/front/src/components/post/Composer.tsx
@@ -1,0 +1,37 @@
+/**
+ * 投稿コンポーザーコンポーネント
+ * アバター＋テキスト入力（上段）＋文字数カウント＋投稿ボタン（下段）
+ * @see doc/input/design/components.json Composer
+ */
+
+export function Composer() {
+  return (
+    <form
+      role="form"
+      aria-label="投稿を作成"
+      className="flex flex-col gap-4 rounded-lg border border-glass-border bg-glass-card p-5 backdrop-blur-[12px]"
+    >
+      {/* 上段: avatar + input, gap 12px */}
+      <div className="flex gap-3">
+        <div className="h-10 w-10 shrink-0 rounded-full bg-sage-muted" />
+        <textarea
+          placeholder="いまどうしてる？"
+          className="min-h-[60px] flex-1 resize-none bg-transparent text-base leading-relaxed text-stone-50 placeholder:text-stone-500 focus:outline-none"
+        />
+      </div>
+      {/* 下段: charCount + button（右寄せ）, gap 12px */}
+      <div className="flex items-center justify-end gap-3">
+        <span className="text-xs text-stone-500">0/140</span>
+        <button
+          type="button"
+          className="rounded-full px-6 py-2.5 text-md font-semibold text-stone-900 shadow-glow-accent"
+          style={{
+            background: 'linear-gradient(135deg, #8BAA7F 0%, #A8D4A0 100%)',
+          }}
+        >
+          投稿する
+        </button>
+      </div>
+    </form>
+  )
+}

--- a/front/src/components/post/PostCard.tsx
+++ b/front/src/components/post/PostCard.tsx
@@ -1,0 +1,44 @@
+/**
+ * 投稿カードコンポーネント
+ * アバター（ellipse）＋投稿本文（ヘッダー＋コンテンツ）を横並び
+ * @see doc/input/design/components.json PostCard
+ */
+
+export interface PostCardProps {
+  /** 著者名 */
+  authorName: string
+  /** ハンドル（@xxx） */
+  handle: string
+  /** 投稿内容 */
+  content: string
+  /** タイムスタンプ表示 */
+  timestamp: string
+  /** アバター背景色のTailwindクラス */
+  avatarColor?: string
+}
+
+export function PostCard({
+  authorName,
+  handle,
+  content,
+  timestamp,
+  avatarColor = 'bg-stone-700',
+}: PostCardProps) {
+  return (
+    <article className="flex gap-3 rounded-lg border border-glass-border bg-glass-card p-5 backdrop-blur-[12px]">
+      <div
+        className={`h-10 w-10 shrink-0 rounded-full ${avatarColor}`}
+      />
+      <div className="flex flex-col gap-2">
+        <div className="flex items-center gap-2">
+          <span className="text-base font-semibold text-stone-50">
+            {authorName}
+          </span>
+          <span className="text-sm text-stone-500">{handle}</span>
+          <span className="text-sm text-stone-500">· {timestamp}</span>
+        </div>
+        <p className="text-base leading-relaxed text-stone-50">{content}</p>
+      </div>
+    </article>
+  )
+}

--- a/front/src/components/ui/Button.tsx
+++ b/front/src/components/ui/Button.tsx
@@ -1,0 +1,68 @@
+/**
+ * 汎用ボタンコンポーネント
+ * tone: primary（gradient fill）/ outline（gradient stroke）
+ * size: sm / md
+ * @see doc/input/design/components.json Button
+ */
+import type { ReactNode } from 'react'
+
+export interface ButtonProps {
+  /** ボタンの見た目 */
+  tone?: 'primary' | 'outline'
+  /** サイズ */
+  size?: 'sm' | 'md'
+  /** ボタンテキスト */
+  children: ReactNode
+  /** クリックハンドラ */
+  onClick?: () => void
+  /** 無効状態 */
+  disabled?: boolean
+  /** ボタンタイプ */
+  type?: 'button' | 'submit'
+}
+
+export function Button({
+  tone = 'primary',
+  size = 'md',
+  children,
+  onClick,
+  disabled = false,
+  type = 'button',
+}: ButtonProps) {
+  const sizeClass =
+    size === 'sm' ? 'px-5 py-2 text-sm' : 'px-6 py-2.5 text-md'
+
+  if (tone === 'outline') {
+    return (
+      <button
+        type={type}
+        onClick={onClick}
+        disabled={disabled}
+        className={`rounded-full bg-transparent font-semibold text-sage-300 shadow-glow-accent-subtle ${sizeClass}`}
+        style={{
+          border: '1px solid transparent',
+          backgroundImage:
+            'linear-gradient(#1C1917, #1C1917), linear-gradient(135deg, #8BAA7F 0%, #A8D4A0 100%)',
+          backgroundOrigin: 'border-box',
+          backgroundClip: 'padding-box, border-box',
+        }}
+      >
+        {children}
+      </button>
+    )
+  }
+
+  return (
+    <button
+      type={type}
+      onClick={onClick}
+      disabled={disabled}
+      className={`rounded-full font-semibold text-stone-900 shadow-glow-accent ${sizeClass}`}
+      style={{
+        background: 'linear-gradient(135deg, #8BAA7F 0%, #A8D4A0 100%)',
+      }}
+    >
+      {children}
+    </button>
+  )
+}

--- a/front/src/components/user/ProfileHeader.tsx
+++ b/front/src/components/user/ProfileHeader.tsx
@@ -1,0 +1,71 @@
+/**
+ * プロフィールヘッダーコンポーネント
+ * アバター＋名前＋ハンドル＋bio＋フォローボタン＋フォロー数/フォロワー数
+ * @see doc/input/design/components.json ProfileHeader
+ */
+import { Button } from '../ui/Button'
+
+export interface ProfileHeaderProps {
+  /** ユーザー名 */
+  name: string
+  /** ハンドル（@xxx） */
+  handle: string
+  /** 自己紹介文 */
+  bio: string
+  /** フォロー中の数 */
+  followingCount: number
+  /** フォロワー数 */
+  followersCount: number
+  /** フォロー中かどうか */
+  isFollowing: boolean
+  /** アバター背景色のTailwindクラス */
+  avatarColor?: string
+}
+
+export function ProfileHeader({
+  name,
+  handle,
+  bio,
+  followingCount,
+  followersCount,
+  isFollowing,
+  avatarColor = 'bg-stone-700',
+}: ProfileHeaderProps) {
+  return (
+    <header
+      role="banner"
+      className="flex flex-col gap-4 rounded-lg border border-glass-border bg-glass-card pb-5 pl-6 pr-6 pt-6 backdrop-blur-[12px]"
+    >
+      {/* 上段: avatar(64px) + info + followButton, gap 16px */}
+      <div className="flex items-center gap-4">
+        <div className={`h-16 w-16 shrink-0 rounded-full ${avatarColor}`} />
+        <div className="flex flex-1 flex-col gap-0.5">
+          <h1 className="text-xl font-bold text-stone-50">{name}</h1>
+          <span className="text-sm text-stone-500">{handle}</span>
+        </div>
+        <Button tone={isFollowing ? 'outline' : 'primary'} size="md">
+          {isFollowing ? 'フォロー中' : 'フォロー'}
+        </Button>
+      </div>
+
+      {/* bio */}
+      <p className="text-md leading-relaxed text-stone-400">{bio}</p>
+
+      {/* フォロー数/フォロワー数: border-top #2E2A25, gap 32px */}
+      <div className="flex gap-8 border-t border-border-subtle pt-3">
+        <div className="flex items-center gap-1.5">
+          <span className="text-lg font-bold text-stone-50">
+            {followingCount}
+          </span>
+          <span className="text-md text-stone-400">フォロー中</span>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <span className="text-lg font-bold text-stone-50">
+            {followersCount}
+          </span>
+          <span className="text-md text-stone-400">フォロワー</span>
+        </div>
+      </div>
+    </header>
+  )
+}

--- a/front/src/components/user/UserCard.tsx
+++ b/front/src/components/user/UserCard.tsx
@@ -1,0 +1,39 @@
+/**
+ * ユーザーカードコンポーネント
+ * アバター（48px ellipse）＋名前＋ハンドル＋フォローボタン
+ * @see doc/input/design/components.json UserCard
+ */
+import { Button } from '../ui/Button'
+
+export interface UserCardProps {
+  /** ユーザー名 */
+  name: string
+  /** ハンドル（@xxx） */
+  handle: string
+  /** フォロー中かどうか */
+  isFollowing: boolean
+  /** アバター背景色のTailwindクラス */
+  avatarColor?: string
+}
+
+export function UserCard({
+  name,
+  handle,
+  isFollowing,
+  avatarColor = 'bg-stone-700',
+}: UserCardProps) {
+  return (
+    <article className="flex items-center gap-4 rounded-lg border border-glass-border bg-glass-card p-5 backdrop-blur-[12px]">
+      {/* アバター: 48px ellipse */}
+      <div className={`h-12 w-12 shrink-0 rounded-full ${avatarColor}`} />
+      {/* ユーザー情報: gap 4px */}
+      <div className="flex flex-1 flex-col gap-1">
+        <span className="text-base font-semibold text-stone-50">{name}</span>
+        <span className="text-sm text-stone-500">{handle}</span>
+      </div>
+      <Button tone={isFollowing ? 'outline' : 'primary'} size="sm">
+        {isFollowing ? 'フォロー中' : 'フォロー'}
+      </Button>
+    </article>
+  )
+}

--- a/front/src/pages/ProfilePage.tsx
+++ b/front/src/pages/ProfilePage.tsx
@@ -1,10 +1,11 @@
 /**
  * プロフィール画面
  * ユーザー情報＋フォロー数/フォロワー数＋投稿一覧を表示。
- * 静的UI骨格（ロジックなし）。#4でコンポーネント分割する。
  * @see doc/input/design/design_context.json ProfilePage
  */
-import { Leaf, Newspaper, Users, User } from 'lucide-react'
+import { Sidebar } from '../components/layout/Sidebar'
+import { ProfileHeader } from '../components/user/ProfileHeader'
+import { PostCard } from '../components/post/PostCard'
 
 /** ダミープロフィールデータ（Sprint 2でFirestore接続に差し替え） */
 const DUMMY_PROFILE = {
@@ -13,6 +14,7 @@ const DUMMY_PROFILE = {
   bio: 'お茶と読書が好き。静かな夜のひとときを大切にしています。',
   followingCount: 12,
   followersCount: 8,
+  isFollowing: true,
   avatarColor: 'bg-honey-muted',
 }
 
@@ -46,149 +48,14 @@ export default function ProfilePage() {
           '#1C1917 radial-gradient(ellipse at 55% 30%, rgba(212,165,116,0.06) 0%, transparent 100%)',
       }}
     >
-      {/* サイドバー */}
-      <nav
-        role="navigation"
-        className="sticky top-0 flex h-svh w-[280px] shrink-0 flex-col border-r border-glass-border backdrop-blur-[16px]"
-        style={{
-          background:
-            '#FFFFFF08 linear-gradient(180deg, rgba(212,165,116,0.03) 0%, #1C1917 100%)',
-        }}
-      >
-        <div className="flex flex-1 flex-col px-6 py-8">
-          <div className="flex items-center gap-3 pb-6">
-            <Leaf className="h-7 w-7 text-sage-300" />
-            <span className="text-xl font-bold text-stone-50">ほっとSNS</span>
-          </div>
+      <Sidebar activePath="/profile/1" />
 
-          <ul className="flex flex-col gap-1">
-            <li>
-              <a
-                href="/"
-                className="flex items-center gap-3 rounded-md px-4 py-3 text-base font-medium text-stone-400"
-              >
-                <Newspaper className="h-5 w-5 text-stone-400" />
-                タイムライン
-              </a>
-            </li>
-            <li>
-              <a
-                href="/users"
-                className="flex items-center gap-3 rounded-md px-4 py-3 text-base font-medium text-stone-400"
-              >
-                <Users className="h-5 w-5 text-stone-400" />
-                ユーザー一覧
-              </a>
-            </li>
-            <li>
-              <a
-                href="/profile/1"
-                className="flex items-center gap-3 rounded-md bg-nav-active px-4 py-3 text-base font-semibold text-stone-50"
-              >
-                <User className="h-5 w-5 text-sage-300" />
-                プロフィール
-              </a>
-            </li>
-          </ul>
-
-          <div className="flex-1" />
-
-          <div className="flex items-center gap-3 border-t border-border-subtle pt-4">
-            <div className="h-10 w-10 rounded-full bg-sage-muted" />
-            <div className="flex flex-col gap-0.5">
-              <span className="text-md font-semibold text-stone-50">
-                さくら
-              </span>
-              <span className="text-xs text-stone-500">@sakura</span>
-            </div>
-          </div>
-        </div>
-      </nav>
-
-      {/* メインコンテンツ: padding 32px 48px, gap 24px */}
       <main className="flex flex-1 flex-col gap-6 overflow-hidden px-12 py-8">
-        {/* プロフィールヘッダー: padding 24px 24px 20px 24px, gap 16px */}
-        <header
-          role="banner"
-          className="flex flex-col gap-4 rounded-lg border border-glass-border bg-glass-card pb-5 pl-6 pr-6 pt-6 backdrop-blur-[12px]"
-        >
-          {/* 上段: avatar + info + followButton */}
-          <div className="flex items-center gap-4">
-            <div
-              className={`h-16 w-16 shrink-0 rounded-full ${DUMMY_PROFILE.avatarColor}`}
-            />
-            <div className="flex flex-1 flex-col gap-0.5">
-              <h1 className="text-xl font-bold text-stone-50">
-                {DUMMY_PROFILE.name}
-              </h1>
-              <span className="text-sm text-stone-500">
-                {DUMMY_PROFILE.handle}
-              </span>
-            </div>
-            {/* フォローボタン: outline, gradient stroke */}
-            <button
-              type="button"
-              className="rounded-full px-6 py-2.5 text-md font-semibold text-sage-300 shadow-glow-accent-subtle"
-              style={{
-                border: '1px solid transparent',
-                backgroundImage:
-                  'linear-gradient(#1C1917, #1C1917), linear-gradient(135deg, #8BAA7F 0%, #A8D4A0 100%)',
-                backgroundOrigin: 'border-box',
-                backgroundClip: 'padding-box, border-box',
-              }}
-            >
-              フォロー中
-            </button>
-          </div>
-
-          {/* bio */}
-          <p className="text-md leading-relaxed text-stone-400">
-            {DUMMY_PROFILE.bio}
-          </p>
-
-          {/* フォロー数/フォロワー数: border-top #2E2A25, gap 32px */}
-          <div className="flex gap-8 border-t border-border-subtle pt-3">
-            <div className="flex items-center gap-1.5">
-              <span className="text-lg font-bold text-stone-50">
-                {DUMMY_PROFILE.followingCount}
-              </span>
-              <span className="text-md text-stone-400">フォロー中</span>
-            </div>
-            <div className="flex items-center gap-1.5">
-              <span className="text-lg font-bold text-stone-50">
-                {DUMMY_PROFILE.followersCount}
-              </span>
-              <span className="text-md text-stone-400">フォロワー</span>
-            </div>
-          </div>
-        </header>
-
-        {/* 投稿セクション: gap 12px */}
+        <ProfileHeader {...DUMMY_PROFILE} />
         <div className="flex flex-col gap-3">
           <h2 className="text-lg font-semibold text-stone-400">投稿</h2>
           {DUMMY_POSTS.map((post) => (
-            <article
-              key={post.id}
-              className="flex gap-3 rounded-lg border border-glass-border bg-glass-card p-5 backdrop-blur-[12px]"
-            >
-              <div
-                className={`h-10 w-10 shrink-0 rounded-full ${post.avatarColor}`}
-              />
-              <div className="flex flex-col gap-2">
-                <div className="flex items-center gap-2">
-                  <span className="text-base font-semibold text-stone-50">
-                    {post.authorName}
-                  </span>
-                  <span className="text-sm text-stone-500">{post.handle}</span>
-                  <span className="text-sm text-stone-500">
-                    · {post.timestamp}
-                  </span>
-                </div>
-                <p className="text-base leading-relaxed text-stone-50">
-                  {post.content}
-                </p>
-              </div>
-            </article>
+            <PostCard key={post.id} {...post} />
           ))}
         </div>
       </main>

--- a/front/src/pages/TimelinePage.tsx
+++ b/front/src/pages/TimelinePage.tsx
@@ -1,10 +1,11 @@
 /**
  * タイムライン画面
  * フォロー中＋自分の投稿をcreatedAt降順で表示。投稿の作成が可能。
- * 静的UI骨格（ロジックなし）。#4でコンポーネント分割する。
  * @see doc/input/design/design_context.json TimelinePage
  */
-import { Leaf, Newspaper, Users, User } from 'lucide-react'
+import { Sidebar } from '../components/layout/Sidebar'
+import { Composer } from '../components/post/Composer'
+import { PostCard } from '../components/post/PostCard'
 
 /** ダミー投稿データ（Sprint 2でFirestore接続に差し替え） */
 const DUMMY_POSTS = [
@@ -46,127 +47,15 @@ export default function TimelinePage() {
           '#1C1917 radial-gradient(ellipse at 55% 30%, rgba(212,165,116,0.06) 0%, transparent 100%)',
       }}
     >
-      {/* サイドバー: glass.sidebar + gradient overlay + backdrop-blur 16px */}
-      <nav
-        role="navigation"
-        className="sticky top-0 flex h-svh w-[280px] shrink-0 flex-col border-r border-glass-border backdrop-blur-[16px]"
-        style={{
-          background:
-            '#FFFFFF08 linear-gradient(180deg, rgba(212,165,116,0.03) 0%, #1C1917 100%)',
-        }}
-      >
-        <div className="flex flex-1 flex-col px-6 py-8">
-          {/* ロゴ: lucide leaf + テキスト */}
-          <div className="flex items-center gap-3 pb-6">
-            <Leaf className="h-7 w-7 text-sage-300" />
-            <span className="text-xl font-bold text-stone-50">ほっとSNS</span>
-          </div>
-
-          {/* ナビゲーション: gap 4px, cornerRadius 12px, padding 12px 16px */}
-          <ul className="flex flex-col gap-1">
-            <li>
-              <a
-                href="/"
-                className="flex items-center gap-3 rounded-md bg-nav-active px-4 py-3 text-base font-semibold text-stone-50"
-              >
-                <Newspaper className="h-5 w-5 text-sage-300" />
-                タイムライン
-              </a>
-            </li>
-            <li>
-              <a
-                href="/users"
-                className="flex items-center gap-3 rounded-md px-4 py-3 text-base font-medium text-stone-400"
-              >
-                <Users className="h-5 w-5 text-stone-400" />
-                ユーザー一覧
-              </a>
-            </li>
-            <li>
-              <a
-                href="/profile/1"
-                className="flex items-center gap-3 rounded-md px-4 py-3 text-base font-medium text-stone-400"
-              >
-                <User className="h-5 w-5 text-stone-400" />
-                プロフィール
-              </a>
-            </li>
-          </ul>
-
-          {/* スペーサー */}
-          <div className="flex-1" />
-
-          {/* 現在のユーザー: border-top #2E2A25, gap 12px */}
-          <div className="flex items-center gap-3 border-t border-border-subtle pt-4">
-            <div className="h-10 w-10 rounded-full bg-sage-muted" />
-            <div className="flex flex-col gap-0.5">
-              <span className="text-md font-semibold text-stone-50">
-                さくら
-              </span>
-              <span className="text-xs text-stone-500">@sakura</span>
-            </div>
-          </div>
-        </div>
-      </nav>
+      <Sidebar activePath="/" />
 
       {/* メインコンテンツ: padding 32px 48px, gap 24px, clip */}
       <main className="flex flex-1 flex-col gap-6 overflow-hidden px-12 py-8">
         <h1 className="text-3xl font-bold text-stone-50">タイムライン</h1>
-
-        {/* コンポーザー: vertical, gap 16px, padding 20px, cornerRadius 16px */}
-        <form
-          role="form"
-          aria-label="投稿を作成"
-          className="flex flex-col gap-4 rounded-lg border border-glass-border bg-glass-card p-5 backdrop-blur-[12px]"
-        >
-          {/* 上段: avatar + input */}
-          <div className="flex gap-3">
-            <div className="h-10 w-10 shrink-0 rounded-full bg-sage-muted" />
-            <textarea
-              placeholder="いまどうしてる？"
-              className="min-h-[60px] flex-1 resize-none bg-transparent text-base leading-relaxed text-stone-50 placeholder:text-stone-500 focus:outline-none"
-            />
-          </div>
-          {/* 下段: charCount + button（右寄せ） */}
-          <div className="flex items-center justify-end gap-3">
-            <span className="text-xs text-stone-500">0/140</span>
-            <button
-              type="button"
-              className="rounded-full px-6 py-2.5 text-md font-semibold text-stone-900 shadow-glow-accent"
-              style={{
-                background: 'linear-gradient(135deg, #8BAA7F 0%, #A8D4A0 100%)',
-              }}
-            >
-              投稿する
-            </button>
-          </div>
-        </form>
-
-        {/* 投稿フィード: gap 12px */}
+        <Composer />
         <div className="flex flex-col gap-3">
           {DUMMY_POSTS.map((post) => (
-            <article
-              key={post.id}
-              className="flex gap-3 rounded-lg border border-glass-border bg-glass-card p-5 backdrop-blur-[12px]"
-            >
-              <div
-                className={`h-10 w-10 shrink-0 rounded-full ${post.avatarColor}`}
-              />
-              <div className="flex flex-col gap-2">
-                <div className="flex items-center gap-2">
-                  <span className="text-base font-semibold text-stone-50">
-                    {post.authorName}
-                  </span>
-                  <span className="text-sm text-stone-500">{post.handle}</span>
-                  <span className="text-sm text-stone-500">
-                    · {post.timestamp}
-                  </span>
-                </div>
-                <p className="text-base leading-relaxed text-stone-50">
-                  {post.content}
-                </p>
-              </div>
-            </article>
+            <PostCard key={post.id} {...post} />
           ))}
         </div>
       </main>

--- a/front/src/pages/UsersPage.tsx
+++ b/front/src/pages/UsersPage.tsx
@@ -1,48 +1,18 @@
 /**
  * ユーザー一覧画面
  * 全ユーザーを表示し、フォロー/アンフォローのトグルが可能。
- * 静的UI骨格（ロジックなし）。#4でコンポーネント分割する。
  * @see doc/input/design/design_context.json UsersPage
  */
-import { Leaf, Newspaper, Users, User } from 'lucide-react'
+import { Sidebar } from '../components/layout/Sidebar'
+import { UserCard } from '../components/user/UserCard'
 
 /** ダミーユーザーデータ（Sprint 2でFirestore接続に差し替え） */
 const DUMMY_USERS = [
-  {
-    id: '1',
-    name: 'さくら',
-    handle: '@sakura',
-    isFollowing: true,
-    avatarColor: 'bg-honey-muted',
-  },
-  {
-    id: '2',
-    name: 'はると',
-    handle: '@haruto',
-    isFollowing: false,
-    avatarColor: 'bg-sage-muted',
-  },
-  {
-    id: '3',
-    name: 'ゆき',
-    handle: '@yuki',
-    isFollowing: true,
-    avatarColor: 'bg-danger-muted',
-  },
-  {
-    id: '4',
-    name: 'りく',
-    handle: '@riku',
-    isFollowing: false,
-    avatarColor: 'bg-honey-muted',
-  },
-  {
-    id: '5',
-    name: 'あおい',
-    handle: '@aoi',
-    isFollowing: false,
-    avatarColor: 'bg-blue-muted',
-  },
+  { id: '1', name: 'さくら', handle: '@sakura', isFollowing: true, avatarColor: 'bg-honey-muted' },
+  { id: '2', name: 'はると', handle: '@haruto', isFollowing: false, avatarColor: 'bg-sage-muted' },
+  { id: '3', name: 'ゆき', handle: '@yuki', isFollowing: true, avatarColor: 'bg-danger-muted' },
+  { id: '4', name: 'りく', handle: '@riku', isFollowing: false, avatarColor: 'bg-honey-muted' },
+  { id: '5', name: 'あおい', handle: '@aoi', isFollowing: false, avatarColor: 'bg-blue-muted' },
 ]
 
 export default function UsersPage() {
@@ -54,115 +24,13 @@ export default function UsersPage() {
           '#1C1917 radial-gradient(ellipse at 55% 30%, rgba(212,165,116,0.06) 0%, transparent 100%)',
       }}
     >
-      {/* サイドバー */}
-      <nav
-        role="navigation"
-        className="sticky top-0 flex h-svh w-[280px] shrink-0 flex-col border-r border-glass-border backdrop-blur-[16px]"
-        style={{
-          background:
-            '#FFFFFF08 linear-gradient(180deg, rgba(212,165,116,0.03) 0%, #1C1917 100%)',
-        }}
-      >
-        <div className="flex flex-1 flex-col px-6 py-8">
-          <div className="flex items-center gap-3 pb-6">
-            <Leaf className="h-7 w-7 text-sage-300" />
-            <span className="text-xl font-bold text-stone-50">ほっとSNS</span>
-          </div>
+      <Sidebar activePath="/users" />
 
-          <ul className="flex flex-col gap-1">
-            <li>
-              <a
-                href="/"
-                className="flex items-center gap-3 rounded-md px-4 py-3 text-base font-medium text-stone-400"
-              >
-                <Newspaper className="h-5 w-5 text-stone-400" />
-                タイムライン
-              </a>
-            </li>
-            <li>
-              <a
-                href="/users"
-                className="flex items-center gap-3 rounded-md bg-nav-active px-4 py-3 text-base font-semibold text-stone-50"
-              >
-                <Users className="h-5 w-5 text-sage-300" />
-                ユーザー一覧
-              </a>
-            </li>
-            <li>
-              <a
-                href="/profile/1"
-                className="flex items-center gap-3 rounded-md px-4 py-3 text-base font-medium text-stone-400"
-              >
-                <User className="h-5 w-5 text-stone-400" />
-                プロフィール
-              </a>
-            </li>
-          </ul>
-
-          <div className="flex-1" />
-
-          <div className="flex items-center gap-3 border-t border-border-subtle pt-4">
-            <div className="h-10 w-10 rounded-full bg-sage-muted" />
-            <div className="flex flex-col gap-0.5">
-              <span className="text-md font-semibold text-stone-50">
-                さくら
-              </span>
-              <span className="text-xs text-stone-500">@sakura</span>
-            </div>
-          </div>
-        </div>
-      </nav>
-
-      {/* メインコンテンツ: padding 32px 48px, gap 24px */}
       <main className="flex flex-1 flex-col gap-6 overflow-hidden px-12 py-8">
         <h1 className="text-3xl font-bold text-stone-50">ユーザー一覧</h1>
-
-        {/* ユーザーリスト: gap 12px */}
         <div className="flex flex-col gap-3">
           {DUMMY_USERS.map((user) => (
-            <article
-              key={user.id}
-              className="flex items-center gap-4 rounded-lg border border-glass-border bg-glass-card p-5 backdrop-blur-[12px]"
-            >
-              {/* アバター: 48px ellipse */}
-              <div
-                className={`h-12 w-12 shrink-0 rounded-full ${user.avatarColor}`}
-              />
-              {/* ユーザー情報: gap 4px */}
-              <div className="flex flex-1 flex-col gap-1">
-                <span className="text-base font-semibold text-stone-50">
-                  {user.name}
-                </span>
-                <span className="text-sm text-stone-500">{user.handle}</span>
-              </div>
-              {/* フォローボタン: outline=gradient stroke, primary=gradient fill */}
-              {user.isFollowing ? (
-                <button
-                  type="button"
-                  className="rounded-full bg-transparent px-5 py-2 text-sm font-semibold text-sage-300 shadow-glow-accent-subtle"
-                  style={{
-                    border: '1px solid transparent',
-                    backgroundImage:
-                      'linear-gradient(#1C1917, #1C1917), linear-gradient(135deg, #8BAA7F 0%, #A8D4A0 100%)',
-                    backgroundOrigin: 'border-box',
-                    backgroundClip: 'padding-box, border-box',
-                  }}
-                >
-                  フォロー中
-                </button>
-              ) : (
-                <button
-                  type="button"
-                  className="rounded-full px-5 py-2 text-sm font-semibold text-stone-900 shadow-glow-accent"
-                  style={{
-                    background:
-                      'linear-gradient(135deg, #8BAA7F 0%, #A8D4A0 100%)',
-                  }}
-                >
-                  フォロー
-                </button>
-              )}
-            </article>
+            <UserCard key={user.id} {...user} />
           ))}
         </div>
       </main>


### PR DESCRIPTION
## Summary
- components.json定義に準拠して7コンポーネントを抽出
- Sidebar / NavItem / PostCard / Composer / UserCard / ProfileHeader / Button
- 3ページをコンポーネントimport + 合成に書き換え
- a11y属性（role, aria-label）をcomponents.json通りに反映

## Test plan
- [x] `pnpm lint` PASS
- [x] `pnpm build` PASS
- [ ] `pnpm dev` で3画面の表示確認（コンポーネント分割前と同じ見た目）

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)