### PR TITLE
feat: コンポーネント結合 + react-router-domルーティング設定

### DIFF
--- a/front/src/App.tsx
+++ b/front/src/App.tsx
@@ -1,18 +1,26 @@
 /**
  * アプリケーションルートコンポーネント
- * #5でreact-router-domによるルーティングに差し替え予定
- * 暫定: URLパスで表示ページを切り替え
+ * react-router-dom v7 によるルーティング設定
+ * @see doc/input/design/design_context.json pages定義
  */
+import { BrowserRouter, Routes, Route } from 'react-router-dom'
+import { MainLayout } from './components/layout/MainLayout'
 import TimelinePage from './pages/TimelinePage'
 import UsersPage from './pages/UsersPage'
 import ProfilePage from './pages/ProfilePage'
 
 function App() {
-  const path = window.location.pathname
-
-  if (path.startsWith('/users')) return <UsersPage />
-  if (path.startsWith('/profile')) return <ProfilePage />
-  return <TimelinePage />
+  return (
+    <BrowserRouter>
+      <Routes>
+        <Route element={<MainLayout />}>
+          <Route path="/" element={<TimelinePage />} />
+          <Route path="/users" element={<UsersPage />} />
+          <Route path="/profile/:userId" element={<ProfilePage />} />
+        </Route>
+      </Routes>
+    </BrowserRouter>
+  )
 }
 
 export default App

--- a/front/src/components/layout/MainLayout.tsx
+++ b/front/src/components/layout/MainLayout.tsx
@@ -1,0 +1,28 @@
+/**
+ * メインレイアウトコンポーネント
+ * Sidebar + メインコンテンツ領域（Outlet）の共通レイアウト
+ * ページ背景のウォームグロー（radial-gradient）もここで一元管理
+ */
+import { Outlet, useLocation } from 'react-router-dom'
+import { Sidebar } from './Sidebar'
+
+export function MainLayout() {
+  const location = useLocation()
+
+  return (
+    <div
+      className="flex min-h-svh bg-stone-900"
+      style={{
+        background:
+          '#1C1917 radial-gradient(ellipse at 55% 30%, rgba(212,165,116,0.06) 0%, transparent 100%)',
+      }}
+    >
+      <Sidebar activePath={location.pathname} />
+
+      {/* メインコンテンツ: padding 32px 48px, gap 24px, clip */}
+      <main className="flex flex-1 flex-col gap-6 overflow-hidden px-12 py-8">
+        <Outlet />
+      </main>
+    </div>
+  )
+}

--- a/front/src/components/navigation/NavItem.tsx
+++ b/front/src/components/navigation/NavItem.tsx
@@ -3,6 +3,7 @@
  * Lucideアイコン＋ラベル。state: default/active
  * @see doc/input/design/components.json NavItem
  */
+import { Link } from 'react-router-dom'
 import { Newspaper, Users, User, type LucideIcon } from 'lucide-react'
 
 const ICON_MAP: Record<string, LucideIcon> = {
@@ -32,8 +33,8 @@ export function NavItem({
   const isActive = state === 'active'
 
   return (
-    <a
-      href={href}
+    <Link
+      to={href}
       className={`flex items-center gap-3 rounded-md px-4 py-3 text-base ${
         isActive
           ? 'bg-nav-active font-semibold text-stone-50'
@@ -46,6 +47,6 @@ export function NavItem({
         />
       )}
       {label}
-    </a>
+    </Link>
   )
 }

--- a/front/src/pages/ProfilePage.tsx
+++ b/front/src/pages/ProfilePage.tsx
@@ -3,7 +3,6 @@
  * ユーザー情報＋フォロー数/フォロワー数＋投稿一覧を表示。
  * @see doc/input/design/design_context.json ProfilePage
  */
-import { Sidebar } from '../components/layout/Sidebar'
 import { ProfileHeader } from '../components/user/ProfileHeader'
 import { PostCard } from '../components/post/PostCard'
 
@@ -41,24 +40,14 @@ const DUMMY_POSTS = [
 
 export default function ProfilePage() {
   return (
-    <div
-      className="flex min-h-svh bg-stone-900"
-      style={{
-        background:
-          '#1C1917 radial-gradient(ellipse at 55% 30%, rgba(212,165,116,0.06) 0%, transparent 100%)',
-      }}
-    >
-      <Sidebar activePath="/profile/1" />
-
-      <main className="flex flex-1 flex-col gap-6 overflow-hidden px-12 py-8">
-        <ProfileHeader {...DUMMY_PROFILE} />
-        <div className="flex flex-col gap-3">
-          <h2 className="text-lg font-semibold text-stone-400">投稿</h2>
-          {DUMMY_POSTS.map((post) => (
-            <PostCard key={post.id} {...post} />
-          ))}
-        </div>
-      </main>
-    </div>
+    <>
+      <ProfileHeader {...DUMMY_PROFILE} />
+      <div className="flex flex-col gap-3">
+        <h2 className="text-lg font-semibold text-stone-400">投稿</h2>
+        {DUMMY_POSTS.map((post) => (
+          <PostCard key={post.id} {...post} />
+        ))}
+      </div>
+    </>
   )
 }

--- a/front/src/pages/TimelinePage.tsx
+++ b/front/src/pages/TimelinePage.tsx
@@ -3,7 +3,6 @@
  * フォロー中＋自分の投稿をcreatedAt降順で表示。投稿の作成が可能。
  * @see doc/input/design/design_context.json TimelinePage
  */
-import { Sidebar } from '../components/layout/Sidebar'
 import { Composer } from '../components/post/Composer'
 import { PostCard } from '../components/post/PostCard'
 
@@ -40,25 +39,14 @@ const DUMMY_POSTS = [
 
 export default function TimelinePage() {
   return (
-    <div
-      className="flex min-h-svh bg-stone-900"
-      style={{
-        background:
-          '#1C1917 radial-gradient(ellipse at 55% 30%, rgba(212,165,116,0.06) 0%, transparent 100%)',
-      }}
-    >
-      <Sidebar activePath="/" />
-
-      {/* メインコンテンツ: padding 32px 48px, gap 24px, clip */}
-      <main className="flex flex-1 flex-col gap-6 overflow-hidden px-12 py-8">
-        <h1 className="text-3xl font-bold text-stone-50">タイムライン</h1>
-        <Composer />
-        <div className="flex flex-col gap-3">
-          {DUMMY_POSTS.map((post) => (
-            <PostCard key={post.id} {...post} />
-          ))}
-        </div>
-      </main>
-    </div>
+    <>
+      <h1 className="text-3xl font-bold text-stone-50">タイムライン</h1>
+      <Composer />
+      <div className="flex flex-col gap-3">
+        {DUMMY_POSTS.map((post) => (
+          <PostCard key={post.id} {...post} />
+        ))}
+      </div>
+    </>
   )
 }

--- a/front/src/pages/UsersPage.tsx
+++ b/front/src/pages/UsersPage.tsx
@@ -3,7 +3,6 @@
  * 全ユーザーを表示し、フォロー/アンフォローのトグルが可能。
  * @see doc/input/design/design_context.json UsersPage
  */
-import { Sidebar } from '../components/layout/Sidebar'
 import { UserCard } from '../components/user/UserCard'
 
 /** ダミーユーザーデータ（Sprint 2でFirestore接続に差し替え） */
@@ -17,23 +16,13 @@ const DUMMY_USERS = [
 
 export default function UsersPage() {
   return (
-    <div
-      className="flex min-h-svh bg-stone-900"
-      style={{
-        background:
-          '#1C1917 radial-gradient(ellipse at 55% 30%, rgba(212,165,116,0.06) 0%, transparent 100%)',
-      }}
-    >
-      <Sidebar activePath="/users" />
-
-      <main className="flex flex-1 flex-col gap-6 overflow-hidden px-12 py-8">
-        <h1 className="text-3xl font-bold text-stone-50">ユーザー一覧</h1>
-        <div className="flex flex-col gap-3">
-          {DUMMY_USERS.map((user) => (
-            <UserCard key={user.id} {...user} />
-          ))}
-        </div>
-      </main>
-    </div>
+    <>
+      <h1 className="text-3xl font-bold text-stone-50">ユーザー一覧</h1>
+      <div className="flex flex-col gap-3">
+        {DUMMY_USERS.map((user) => (
+          <UserCard key={user.id} {...user} />
+        ))}
+      </div>
+    </>
   )
 }


### PR DESCRIPTION
## Summary
- MainLayout（Sidebar + Outlet + ページ背景）を作成し、レイアウトを一元管理
- react-router-dom v7 で3画面をルーティング（`/`, `/users`, `/profile/:userId`）
- NavItem を `<Link>` に変更（SPA遷移、フルリロードなし）
- 各ページからレイアウト部分を除去（コンテンツのみに簡素化）

## Test plan
- [x] `pnpm lint` PASS
- [x] `pnpm build` PASS
- [ ] `pnpm dev` で `/` → `/users` → `/profile/1` の画面遷移確認
- [ ] NavItemのactive状態が正しく切り替わること

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)