### PR TITLE
feat: ユーザー一覧をFirestoreから取得・表示 (#7)

### DIFF
--- a/front/src/components/user/UserCard.tsx
+++ b/front/src/components/user/UserCard.tsx
@@ -1,11 +1,15 @@
 /**
  * ユーザーカードコンポーネント
  * アバター（48px ellipse）＋名前＋ハンドル＋フォローボタン
+ * viewerIdと一致するユーザーにはフォローボタンを表示しない（自分自身のフォロー防止）
  * @see doc/input/design/components.json UserCard
  */
 import { Button } from '../ui/Button'
+import { VIEWER_ID } from '../../lib/constants'
 
 export interface UserCardProps {
+  /** ユーザーID（viewerId判定に使用） */
+  id: string
   /** ユーザー名 */
   name: string
   /** ハンドル（@xxx） */
@@ -14,14 +18,25 @@ export interface UserCardProps {
   isFollowing: boolean
   /** アバター背景色のTailwindクラス */
   avatarColor?: string
+  /** フォロートグル時のコールバック（#8で実装予定） */
+  onToggleFollow?: (userId: string) => void
 }
 
+/**
+ * ユーザーカードを描画する
+ * @param props - ユーザー情報とフォロー状態
+ */
 export function UserCard({
+  id,
   name,
   handle,
   isFollowing,
   avatarColor = 'bg-stone-700',
+  onToggleFollow,
 }: UserCardProps) {
+  /** 自分自身にはフォローボタンを表示しない */
+  const isSelf = id === VIEWER_ID
+
   return (
     <article className="flex items-center gap-4 rounded-lg border border-glass-border bg-glass-card p-5 backdrop-blur-[12px]">
       {/* アバター: 48px ellipse */}
@@ -31,9 +46,15 @@ export function UserCard({
         <span className="text-base font-semibold text-stone-50">{name}</span>
         <span className="text-sm text-stone-400">{handle}</span>
       </div>
-      <Button tone={isFollowing ? 'outline' : 'primary'} size="sm">
-        {isFollowing ? 'フォロー中' : 'フォロー'}
-      </Button>
+      {!isSelf && (
+        <Button
+          tone={isFollowing ? 'outline' : 'primary'}
+          size="sm"
+          onClick={() => onToggleFollow?.(id)}
+        >
+          {isFollowing ? 'フォロー中' : 'フォロー'}
+        </Button>
+      )}
     </article>
   )
 }

--- a/front/src/pages/UsersPage.tsx
+++ b/front/src/pages/UsersPage.tsx
@@ -62,7 +62,7 @@ export default function UsersPage() {
 
       {/* データ取得済み・空の場合 */}
       {loadState === 'ready' && users.length === 0 && (
-        <p className="text-center text-stone-400">
+        <p className="text-center text-stone-400" role="status">
           ユーザーが見つかりませんでした。
         </p>
       )}
@@ -76,7 +76,7 @@ export default function UsersPage() {
               id={user.id}
               name={user.name}
               handle={user.handle}
-              isFollowing={false}
+              isFollowing={false} /* TODO: #8 フォロー状態はfollowsコレクションから取得する */
               avatarColor={user.avatarColor}
             />
           ))}

--- a/front/src/pages/UsersPage.tsx
+++ b/front/src/pages/UsersPage.tsx
@@ -1,28 +1,87 @@
 /**
  * ユーザー一覧画面
- * 全ユーザーを表示し、フォロー/アンフォローのトグルが可能。
+ * FirestoreのusersコレクションをonSnapshotでリアルタイム取得し、全ユーザーを表示する。
+ * viewerId（さくら）のカードではフォローボタンを非表示にする。
  * @see doc/input/design/design-context.json UsersPage
  */
+import { useEffect, useState } from 'react'
+import { collection, onSnapshot } from 'firebase/firestore'
+import { db } from '../lib/firebase'
+import type { User } from '../lib/types'
 import { UserCard } from '../components/user/UserCard'
 
-/** ダミーユーザーデータ（Sprint 2でFirestore接続に差し替え） */
-const DUMMY_USERS = [
-  { id: '1', name: 'さくら', handle: '@sakura', isFollowing: true, avatarColor: 'bg-honey-muted' },
-  { id: '2', name: 'はると', handle: '@haruto', isFollowing: false, avatarColor: 'bg-sage-muted' },
-  { id: '3', name: 'ゆき', handle: '@yuki', isFollowing: true, avatarColor: 'bg-danger-muted' },
-  { id: '4', name: 'りく', handle: '@riku', isFollowing: false, avatarColor: 'bg-honey-muted' },
-  { id: '5', name: 'あおい', handle: '@aoi', isFollowing: false, avatarColor: 'bg-blue-muted' },
-]
+/** Firestoreの接続状態を表す型 */
+type LoadState = 'loading' | 'ready' | 'error'
 
+/**
+ * ユーザー一覧ページコンポーネント
+ * Firestoreからユーザーをリアルタイム取得し、loading / empty / error の各状態をハンドリングする
+ */
 export default function UsersPage() {
+  const [users, setUsers] = useState<User[]>([])
+  const [loadState, setLoadState] = useState<LoadState>('loading')
+
+  useEffect(() => {
+    /** usersコレクションをリアルタイム監視し、変更を即座にUIに反映する */
+    const unsubscribe = onSnapshot(
+      collection(db, 'users'),
+      (snapshot) => {
+        const fetchedUsers = snapshot.docs.map((doc) => ({
+          ...doc.data(),
+          id: doc.id,
+        })) as User[]
+        setUsers(fetchedUsers)
+        setLoadState('ready')
+      },
+      (err) => {
+        console.error('ユーザー一覧の取得に失敗しました:', err)
+        setLoadState('error')
+      },
+    )
+
+    return unsubscribe
+  }, [])
+
   return (
     <>
       <h1 className="text-3xl font-bold text-stone-50">ユーザー一覧</h1>
-      <div className="flex flex-col gap-3">
-        {DUMMY_USERS.map((user) => (
-          <UserCard key={user.id} {...user} />
-        ))}
-      </div>
+
+      {/* ローディング状態 */}
+      {loadState === 'loading' && (
+        <p className="text-center text-stone-400" role="status">
+          読み込み中...
+        </p>
+      )}
+
+      {/* エラー状態 */}
+      {loadState === 'error' && (
+        <p className="text-center text-red-400" role="alert">
+          ユーザーの読み込みに失敗しました。Firebase Emulatorが起動しているか確認してください。
+        </p>
+      )}
+
+      {/* データ取得済み・空の場合 */}
+      {loadState === 'ready' && users.length === 0 && (
+        <p className="text-center text-stone-400">
+          ユーザーが見つかりませんでした。
+        </p>
+      )}
+
+      {/* ユーザー一覧 */}
+      {loadState === 'ready' && users.length > 0 && (
+        <div className="flex flex-col gap-3">
+          {users.map((user) => (
+            <UserCard
+              key={user.id}
+              id={user.id}
+              name={user.name}
+              handle={user.handle}
+              isFollowing={false}
+              avatarColor={user.avatarColor}
+            />
+          ))}
+        </div>
+      )}
     </>
   )
 }


### PR DESCRIPTION
## Summary
- FirestoreのusersコレクションをonSnapshotでリアルタイム取得して表示
- viewerId（さくら / ID=1）のカードではフォローボタンを非表示に
- loading / empty / error 状態のハンドリングを実装

Closes #7

## 変更ファイル
- `front/src/pages/UsersPage.tsx` — ダミーデータ削除、Firestoreリアルタイム取得に差し替え
- `front/src/components/user/UserCard.tsx` — `id` / `onToggleFollow` prop追加、viewerId判定でフォローボタン非表示

## Test plan
- [ ] Firebase Emulator起動（`pnpm emulators:start`）
- [ ] シードデータ投入（`pnpm seed`）
- [ ] 開発サーバー起動（`cd front && pnpm dev`）
- [ ] `/users` 画面で全ユーザーが表示されることを確認
- [ ] さくら（ID=1）のカードにフォローボタンが表示されないことを確認
- [ ] 他ユーザーのカードにフォローボタンが表示されることを確認
- [ ] Emulator停止時にエラーメッセージが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)