### PR TITLE
feat: フォロー/アンフォロートグル実装 (#8)

### DIFF
--- a/front/src/components/ui/Button.tsx
+++ b/front/src/components/ui/Button.tsx
@@ -4,21 +4,16 @@
  * size: sm / md
  * @see doc/input/design/components.json Button
  */
-import type { ReactNode } from 'react'
+import type { ButtonHTMLAttributes, ReactNode } from 'react'
 
-export interface ButtonProps {
+export interface ButtonProps
+  extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'children'> {
   /** ボタンの見た目 */
   tone?: 'primary' | 'outline'
   /** サイズ */
   size?: 'sm' | 'md'
   /** ボタンテキスト */
   children: ReactNode
-  /** クリックハンドラ */
-  onClick?: () => void
-  /** 無効状態 */
-  disabled?: boolean
-  /** ボタンタイプ */
-  type?: 'button' | 'submit'
 }
 
 export function Button({
@@ -28,6 +23,7 @@ export function Button({
   onClick,
   disabled = false,
   type = 'button',
+  ...rest
 }: ButtonProps) {
   const sizeClass =
     size === 'sm' ? 'px-5 py-2 text-sm' : 'px-6 py-2.5 text-md'
@@ -46,6 +42,7 @@ export function Button({
           backgroundOrigin: 'border-box',
           backgroundClip: 'padding-box, border-box',
         }}
+        {...rest}
       >
         {children}
       </button>
@@ -61,6 +58,7 @@ export function Button({
       style={{
         background: 'linear-gradient(135deg, #8BAA7F 0%, #A8D4A0 100%)',
       }}
+      {...rest}
     >
       {children}
     </button>

--- a/front/src/components/user/UserCard.tsx
+++ b/front/src/components/user/UserCard.tsx
@@ -4,6 +4,7 @@
  * viewerIdと一致するユーザーにはフォローボタンを表示しない（自分自身のフォロー防止）
  * @see doc/input/design/components.json UserCard
  */
+import { useState } from 'react'
 import { Button } from '../ui/Button'
 import { VIEWER_ID } from '../../lib/constants'
 
@@ -18,12 +19,13 @@ export interface UserCardProps {
   isFollowing: boolean
   /** アバター背景色のTailwindクラス */
   avatarColor?: string
-  /** フォロートグル時のコールバック（#8で実装予定） */
-  onToggleFollow?: (userId: string) => void
+  /** フォロートグル時のコールバック */
+  onToggleFollow?: (userId: string) => Promise<void> | void
 }
 
 /**
  * ユーザーカードを描画する
+ * フォローボタン押下時は連打防止のためdisabled状態にし、処理完了後に解除する
  * @param props - ユーザー情報とフォロー状態
  */
 export function UserCard({
@@ -36,6 +38,24 @@ export function UserCard({
 }: UserCardProps) {
   /** 自分自身にはフォローボタンを表示しない */
   const isSelf = id === VIEWER_ID
+  /** フォロートグル処理中フラグ（連打防止） */
+  const [isToggling, setIsToggling] = useState(false)
+
+  /**
+   * フォローボタン押下ハンドラ
+   * 処理中はボタンをdisabledにして連打を防止する
+   */
+  const handleClick = async () => {
+    if (!onToggleFollow || isToggling) return
+    setIsToggling(true)
+    try {
+      await onToggleFollow(id)
+    } catch (err) {
+      console.error('フォロー操作に失敗しました:', err)
+    } finally {
+      setIsToggling(false)
+    }
+  }
 
   return (
     <article className="flex items-center gap-4 rounded-lg border border-glass-border bg-glass-card p-5 backdrop-blur-[12px]">
@@ -50,7 +70,8 @@ export function UserCard({
         <Button
           tone={isFollowing ? 'outline' : 'primary'}
           size="sm"
-          onClick={() => onToggleFollow?.(id)}
+          onClick={handleClick}
+          disabled={isToggling}
         >
           {isFollowing ? 'フォロー中' : 'フォロー'}
         </Button>

--- a/front/src/components/user/UserCard.tsx
+++ b/front/src/components/user/UserCard.tsx
@@ -72,6 +72,8 @@ export function UserCard({
           size="sm"
           onClick={handleClick}
           disabled={isToggling}
+          aria-label={isFollowing ? `${name}のフォローを解除` : `${name}をフォロー`}
+          aria-busy={isToggling}
         >
           {isFollowing ? 'フォロー中' : 'フォロー'}
         </Button>

--- a/front/src/pages/UsersPage.tsx
+++ b/front/src/pages/UsersPage.tsx
@@ -1,12 +1,23 @@
 /**
  * ユーザー一覧画面
- * FirestoreのusersコレクションをonSnapshotでリアルタイム取得し、全ユーザーを表示する。
+ * FirestoreのusersコレクションとfollowsコレクションをonSnapshotでリアルタイム取得し、
+ * 全ユーザーのフォロー状態付きで表示する。
  * viewerId（さくら）のカードではフォローボタンを非表示にする。
  * @see doc/input/design/design-context.json UsersPage
  */
 import { useEffect, useState } from 'react'
-import { collection, onSnapshot } from 'firebase/firestore'
+import {
+  collection,
+  onSnapshot,
+  doc,
+  setDoc,
+  deleteDoc,
+  serverTimestamp,
+  query,
+  where,
+} from 'firebase/firestore'
 import { db } from '../lib/firebase'
+import { VIEWER_ID } from '../lib/constants'
 import type { User } from '../lib/types'
 import { UserCard } from '../components/user/UserCard'
 
@@ -15,20 +26,23 @@ type LoadState = 'loading' | 'ready' | 'error'
 
 /**
  * ユーザー一覧ページコンポーネント
- * Firestoreからユーザーをリアルタイム取得し、loading / empty / error の各状態をハンドリングする
+ * Firestoreからユーザーとフォロー状態をリアルタイム取得し、
+ * loading / empty / error の各状態をハンドリングする
  */
 export default function UsersPage() {
   const [users, setUsers] = useState<User[]>([])
   const [loadState, setLoadState] = useState<LoadState>('loading')
+  /** viewerがフォロー中のユーザーIDセット（onSnapshotで自動同期） */
+  const [followingIds, setFollowingIds] = useState<Set<string>>(new Set())
 
   useEffect(() => {
     /** usersコレクションをリアルタイム監視し、変更を即座にUIに反映する */
-    const unsubscribe = onSnapshot(
+    const unsubUsers = onSnapshot(
       collection(db, 'users'),
       (snapshot) => {
-        const fetchedUsers = snapshot.docs.map((doc) => ({
-          ...doc.data(),
-          id: doc.id,
+        const fetchedUsers = snapshot.docs.map((d) => ({
+          ...d.data(),
+          id: d.id,
         })) as User[]
         setUsers(fetchedUsers)
         setLoadState('ready')
@@ -39,8 +53,55 @@ export default function UsersPage() {
       },
     )
 
-    return unsubscribe
+    /** followsコレクションからviewerのフォロー一覧をリアルタイム監視する */
+    const followsQuery = query(
+      collection(db, 'follows'),
+      where('followerId', '==', VIEWER_ID),
+    )
+    const unsubFollows = onSnapshot(
+      followsQuery,
+      (snapshot) => {
+        const ids = new Set<string>()
+        snapshot.docs.forEach((d) => {
+          const data = d.data()
+          ids.add(data.followeeId as string)
+        })
+        setFollowingIds(ids)
+      },
+      (err) => {
+        console.error('フォロー状態の取得に失敗しました:', err)
+      },
+    )
+
+    return () => {
+      unsubUsers()
+      unsubFollows()
+    }
   }, [])
+
+  /**
+   * フォロー/アンフォローをトグルする
+   * onSnapshotがFirestoreの変更を検知してUIを自動更新するため、明示的な楽観的更新は不要
+   * @param userId - 対象ユーザーID
+   * @param isCurrentlyFollowing - 現在フォロー中かどうか
+   */
+  const handleToggleFollow = async (
+    userId: string,
+    isCurrentlyFollowing: boolean,
+  ) => {
+    const docId = `${VIEWER_ID}_${userId}`
+    const docRef = doc(db, 'follows', docId)
+
+    if (isCurrentlyFollowing) {
+      await deleteDoc(docRef)
+    } else {
+      await setDoc(docRef, {
+        followerId: VIEWER_ID,
+        followeeId: userId,
+        createdAt: serverTimestamp(),
+      })
+    }
+  }
 
   return (
     <>
@@ -56,7 +117,8 @@ export default function UsersPage() {
       {/* エラー状態 */}
       {loadState === 'error' && (
         <p className="text-center text-red-400" role="alert">
-          ユーザーの読み込みに失敗しました。Firebase Emulatorが起動しているか確認してください。
+          ユーザーの読み込みに失敗しました。Firebase
+          Emulatorが起動しているか確認してください。
         </p>
       )}
 
@@ -70,16 +132,20 @@ export default function UsersPage() {
       {/* ユーザー一覧 */}
       {loadState === 'ready' && users.length > 0 && (
         <div className="flex flex-col gap-3">
-          {users.map((user) => (
-            <UserCard
-              key={user.id}
-              id={user.id}
-              name={user.name}
-              handle={user.handle}
-              isFollowing={false} /* TODO: #8 フォロー状態はfollowsコレクションから取得する */
-              avatarColor={user.avatarColor}
-            />
-          ))}
+          {users.map((user) => {
+            const isFollowing = followingIds.has(user.id)
+            return (
+              <UserCard
+                key={user.id}
+                id={user.id}
+                name={user.name}
+                handle={user.handle}
+                isFollowing={isFollowing}
+                avatarColor={user.avatarColor}
+                onToggleFollow={(uid) => handleToggleFollow(uid, isFollowing)}
+              />
+            )
+          })}
         </div>
       )}
     </>


### PR DESCRIPTION
## Summary
- followsコレクションをonSnapshotでリアルタイム監視し、viewerのフォロー状態をUIに反映
- setDoc/deleteDocによるフォロー/アンフォロートグル操作
- UserCard内にloading stateを持ち、処理中はボタンdisabledで連打防止

Closes #8

## 変更ファイル
- `front/src/pages/UsersPage.tsx` — follows監視 + handleToggleFollow追加
- `front/src/components/user/UserCard.tsx` — 連打防止 + async handleClick

## Test plan
- [ ] Firebase Emulator起動 (`pnpm emulators:start`)
- [ ] シードデータ投入 (`cd back && pnpm seed`)
- [ ] 開発サーバー起動 (`cd front && pnpm dev`)
- [ ] /users画面で「フォロー」ボタン押下 → ボタンが「フォロー中」に変化することを確認
- [ ] 「フォロー中」ボタン押下 → ボタンが「フォロー」に戻ることを確認
- [ ] 連打しても二重リクエストが発生しないことを確認
- [ ] さくら（viewerId）のカードにはフォローボタンが表示されないことを確認
- [ ] Emulator UI (localhost:4000) でfollowsコレクションのドキュメント作成/削除を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)