### PR TITLE
feat: ユーザー名→プロフィール遷移リンク追加 (#12)

### DIFF
--- a/front/src/components/post/PostCard.tsx
+++ b/front/src/components/post/PostCard.tsx
@@ -1,8 +1,10 @@
 /**
  * 投稿カードコンポーネント
  * アバター（ellipse）＋投稿本文（ヘッダー＋コンテンツ）を横並び
+ * authorIdが指定されている場合、著者名がプロフィールページへのリンクになる
  * @see doc/input/design/components.json PostCard
  */
+import { Link } from 'react-router-dom'
 
 export interface PostCardProps {
   /** 著者のユーザーID（プロフィール遷移リンク用） */
@@ -19,13 +21,33 @@ export interface PostCardProps {
   avatarColor?: string
 }
 
+/**
+ * 投稿カードを描画する
+ * authorIdが存在する場合、著者名をプロフィールページへのリンクとして表示する
+ * @param props - 投稿情報（著者名、ハンドル、内容、タイムスタンプ）
+ */
 export function PostCard({
+  authorId,
   authorName,
   handle,
   content,
   timestamp,
   avatarColor = 'bg-stone-700',
 }: PostCardProps) {
+  /** 著者名の表示要素。authorIdがある場合はプロフィールへのリンクにする */
+  const authorNameElement = authorId ? (
+    <Link
+      to={`/profile/${authorId}`}
+      className="text-base font-semibold text-stone-50 transition-colors hover:text-sage-400 focus-visible:rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sage-400"
+    >
+      {authorName}
+    </Link>
+  ) : (
+    <span className="text-base font-semibold text-stone-50">
+      {authorName}
+    </span>
+  )
+
   return (
     <article className="flex gap-3 rounded-lg border border-glass-border bg-glass-card p-5 backdrop-blur-[12px]">
       <div
@@ -33,9 +55,7 @@ export function PostCard({
       />
       <div className="flex flex-col gap-2">
         <div className="flex items-center gap-2">
-          <span className="text-base font-semibold text-stone-50">
-            {authorName}
-          </span>
+          {authorNameElement}
           <span className="text-sm text-stone-400">{handle}</span>
           <span className="text-sm text-stone-400">· {timestamp}</span>
         </div>

--- a/front/src/components/post/PostCard.tsx
+++ b/front/src/components/post/PostCard.tsx
@@ -38,6 +38,7 @@ export function PostCard({
   const authorNameElement = authorId ? (
     <Link
       to={`/profile/${authorId}`}
+      aria-label={`${authorName}のプロフィールを表示`}
       className="text-base font-semibold text-stone-50 transition-colors hover:text-sage-400 focus-visible:rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sage-400"
     >
       {authorName}

--- a/front/src/components/user/UserCard.tsx
+++ b/front/src/components/user/UserCard.tsx
@@ -67,6 +67,7 @@ export function UserCard({
         {/* ユーザー名: プロフィールページへのリンク */}
         <Link
           to={`/profile/${id}`}
+          aria-label={`${name}のプロフィールを表示`}
           className="text-base font-semibold text-stone-50 transition-colors hover:text-sage-400 focus-visible:rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sage-400"
         >
           {name}

--- a/front/src/components/user/UserCard.tsx
+++ b/front/src/components/user/UserCard.tsx
@@ -5,6 +5,7 @@
  * @see doc/input/design/components.json UserCard
  */
 import { useState } from 'react'
+import { Link } from 'react-router-dom'
 import { Button } from '../ui/Button'
 import { VIEWER_ID } from '../../lib/constants'
 
@@ -63,7 +64,13 @@ export function UserCard({
       <div className={`h-12 w-12 shrink-0 rounded-full ${avatarColor}`} />
       {/* ユーザー情報: gap 4px */}
       <div className="flex flex-1 flex-col gap-1">
-        <span className="text-base font-semibold text-stone-50">{name}</span>
+        {/* ユーザー名: プロフィールページへのリンク */}
+        <Link
+          to={`/profile/${id}`}
+          className="text-base font-semibold text-stone-50 transition-colors hover:text-sage-400 focus-visible:rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sage-400"
+        >
+          {name}
+        </Link>
         <span className="text-sm text-stone-400">{handle}</span>
       </div>
       {!isSelf && (


### PR DESCRIPTION
## Summary
- PostCard: `authorName` を `<Link to="/profile/:authorId">` でラップし、プロフィール遷移を実現
- UserCard: `name` を `<Link to="/profile/:id">` でラップし、プロフィール遷移を実現
- hover時に `text-sage-400` 色変化、`focus-visible` 時にリング表示でアクセシビリティ確保

## Test plan
- [ ] タイムライン画面で投稿者名をクリック → プロフィール画面に遷移すること
- [ ] ユーザー一覧画面でユーザー名をクリック → プロフィール画面に遷移すること
- [ ] hover時にsage-400色に変化すること
- [ ] Tabキーでフォーカス移動し、focus-visibleリングが表示されること
- [ ] `authorId` がない場合（通常テキスト）にリンクにならないこと
- [ ] `pnpm lint` が通ること
- [ ] `pnpm build` が通ること

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)