### PR TITLE
feat: キーボードショートカット追加 (#33)

### DIFF
--- a/front/src/components/layout/MainLayout.tsx
+++ b/front/src/components/layout/MainLayout.tsx
@@ -6,12 +6,25 @@
  * ページ背景のウォームグロー（radial-gradient）もここで一元管理
  * @see doc/input/design/design-context.json responsive
  */
+import { useState, useCallback } from 'react'
 import { Outlet, useLocation } from 'react-router-dom'
 import { Sidebar } from './Sidebar'
 import { BottomNavBar } from '../navigation/BottomNavBar'
+import { ShortcutHelpModal } from '../ui/ShortcutHelpModal'
+import { useKeyboardShortcuts } from '../../hooks/useKeyboardShortcuts'
 
 export function MainLayout() {
   const location = useLocation()
+  /** ショートカットヘルプモーダルの表示状態 */
+  const [showHelp, setShowHelp] = useState(false)
+
+  /** ヘルプモーダルの表示/非表示を切り替える */
+  const handleToggleHelp = useCallback(() => {
+    setShowHelp((prev) => !prev)
+  }, [])
+
+  // グローバルキーボードショートカットを登録
+  useKeyboardShortcuts(handleToggleHelp)
 
   return (
     <div
@@ -34,6 +47,9 @@ export function MainLayout() {
 
       {/* Mobile: ボトムナビバー（md以上で非表示） */}
       <BottomNavBar activePath={location.pathname} />
+
+      {/* ショートカットヘルプモーダル */}
+      <ShortcutHelpModal isOpen={showHelp} onClose={() => setShowHelp(false)} />
     </div>
   )
 }

--- a/front/src/components/post/Composer.tsx
+++ b/front/src/components/post/Composer.tsx
@@ -32,6 +32,17 @@ export function Composer() {
   const isDisabled = isEmpty || isOverLimit || isSubmitting
 
   /**
+   * Ctrl+Enter（Win）/ Cmd+Enter（Mac）で投稿を送信するキーハンドラ
+   * @param e キーボードイベント
+   */
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
+      e.preventDefault()
+      handleSubmit()
+    }
+  }
+
+  /**
    * 投稿をFirestoreに保存する
    * postsコレクションにドキュメントを追加し、成功時に入力をクリアする
    */
@@ -73,6 +84,7 @@ export function Composer() {
           placeholder="いまどうしてる？"
           value={content}
           onChange={(e) => setContent(e.target.value)}
+          onKeyDown={handleKeyDown}
           disabled={isSubmitting}
           className="min-h-[60px] flex-1 resize-none bg-transparent text-base leading-relaxed text-stone-50 placeholder:text-stone-400 focus:outline-none focus-visible:ring-2 focus-visible:ring-sage-300 focus-visible:ring-offset-2 focus-visible:ring-offset-stone-900 disabled:opacity-50"
         />

--- a/front/src/components/ui/ShortcutHelpModal.tsx
+++ b/front/src/components/ui/ShortcutHelpModal.tsx
@@ -1,0 +1,131 @@
+/**
+ * ショートカットヘルプモーダルコンポーネント
+ * キーボードショートカットの一覧を表示するダイアログ
+ * - ?キーで開き、Escapeキーで閉じる
+ * - WAI-ARIA準拠: role="dialog", aria-modal, aria-label
+ * - フォーカストラップ: 開いた時に閉じるボタンへフォーカス
+ * - オーバーレイクリックで閉じる
+ */
+import { useEffect, useRef } from 'react'
+
+/** macOS判定: Cmd/Ctrlの表示切替に使用 */
+const isMac =
+  typeof navigator !== 'undefined' && navigator.userAgent.includes('Mac')
+
+/** ショートカット定義 */
+const SHORTCUTS = [
+  { keys: `${isMac ? 'Cmd' : 'Ctrl'} + Enter`, description: '投稿を送信' },
+  { keys: '1', description: 'タイムライン' },
+  { keys: '2', description: 'ユーザー一覧' },
+  { keys: '3', description: 'プロフィール' },
+  { keys: '?', description: 'このヘルプを表示' },
+  { keys: 'Escape', description: '閉じる' },
+] as const
+
+/**
+ * ショートカットヘルプモーダルのProps
+ */
+interface ShortcutHelpModalProps {
+  /** モーダルの表示状態 */
+  isOpen: boolean
+  /** モーダルを閉じるコールバック */
+  onClose: () => void
+}
+
+/**
+ * キーボードショートカットの一覧を表示するモーダルダイアログ
+ * グラスモーフィズムスタイルでデザインシステムに準拠
+ * @param props モーダルの表示制御プロパティ
+ */
+export function ShortcutHelpModal({ isOpen, onClose }: ShortcutHelpModalProps) {
+  const closeButtonRef = useRef<HTMLButtonElement>(null)
+
+  // モーダル表示時にフォーカストラップ: 閉じるボタンへフォーカス
+  useEffect(() => {
+    if (isOpen) {
+      closeButtonRef.current?.focus()
+    }
+  }, [isOpen])
+
+  // Escapeキーでモーダルを閉じる
+  useEffect(() => {
+    if (!isOpen) return
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        onClose()
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [isOpen, onClose])
+
+  if (!isOpen) return null
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm"
+      onClick={onClose}
+      role="presentation"
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="キーボードショートカット"
+        className="mx-4 w-full max-w-md rounded-xl border border-glass-border bg-glass-card p-6 shadow-xl backdrop-blur-md"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* ヘッダー: タイトル + 閉じるボタン */}
+        <div className="mb-4 flex items-center justify-between">
+          <h2 className="text-lg font-semibold text-stone-50">
+            キーボードショートカット
+          </h2>
+          <button
+            ref={closeButtonRef}
+            onClick={onClose}
+            className="rounded-md p-1 text-stone-400 transition-colors hover:text-stone-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sage-300"
+            aria-label="閉じる"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="20"
+              height="20"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <line x1="18" y1="6" x2="6" y2="18" />
+              <line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
+          </button>
+        </div>
+
+        {/* ショートカット一覧テーブル */}
+        <table className="w-full">
+          <tbody>
+            {SHORTCUTS.map((shortcut) => (
+              <tr
+                key={shortcut.keys}
+                className="border-t border-stone-700/50"
+              >
+                <td className="py-2.5 pr-4">
+                  <kbd className="rounded bg-stone-700 px-2 py-0.5 font-mono text-sm text-stone-300">
+                    {shortcut.keys}
+                  </kbd>
+                </td>
+                <td className="py-2.5 text-sm text-stone-300">
+                  {shortcut.description}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}

--- a/front/src/hooks/useKeyboardShortcuts.ts
+++ b/front/src/hooks/useKeyboardShortcuts.ts
@@ -1,0 +1,62 @@
+/**
+ * グローバルキーボードショートカットのカスタムフック
+ * ページナビゲーション（1/2/3）とヘルプモーダル表示（?）を提供する
+ * WCAG 2.1.4 準拠: 単独文字キーは入力フィールド外でのみ有効
+ */
+import { useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { NAV_ITEMS } from '../lib/navigation'
+
+/**
+ * 入力フィールドにフォーカスがあるか判定する
+ * input/textarea/[contenteditable]にフォーカスがある場合はグローバルショートカットを無効化
+ * @returns 入力フィールドにフォーカスがあればtrue
+ */
+function isInputFocused(): boolean {
+  const el = document.activeElement
+  if (!el) return false
+  const tagName = el.tagName.toLowerCase()
+  return (
+    tagName === 'input' ||
+    tagName === 'textarea' ||
+    el.hasAttribute('contenteditable')
+  )
+}
+
+/**
+ * グローバルキーボードショートカットを登録するフック
+ * - 1: タイムラインへ遷移
+ * - 2: ユーザー一覧へ遷移
+ * - 3: プロフィールへ遷移
+ * - ?: ショートカットヘルプモーダルの表示切替
+ * @param onToggleHelp ヘルプモーダルの表示/非表示を切り替えるコールバック
+ */
+export function useKeyboardShortcuts(onToggleHelp: () => void) {
+  const navigate = useNavigate()
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      // 入力フィールド内ではグローバルショートカット無効
+      if (isInputFocused()) return
+
+      switch (e.key) {
+        case '1':
+          navigate(NAV_ITEMS[0].href) // タイムライン
+          break
+        case '2':
+          navigate(NAV_ITEMS[1].href) // ユーザー一覧
+          break
+        case '3':
+          navigate(NAV_ITEMS[2].href) // プロフィール
+          break
+        case '?':
+          e.preventDefault()
+          onToggleHelp()
+          break
+      }
+    }
+
+    document.addEventListener('keydown', handler)
+    return () => document.removeEventListener('keydown', handler)
+  }, [navigate, onToggleHelp])
+}


### PR DESCRIPTION
## Summary
- Ctrl/Cmd+Enter で投稿送信（Composer内 onKeyDown）
- 1/2/3 キーでページナビゲーション（入力フィールド外のみ、WCAG 2.1.4 準拠）
- ? キーでショートカットヘルプモーダル表示、Escape で閉じる
- WAI-ARIA 準拠のモーダル（role="dialog", aria-modal, フォーカストラップ）

## Test plan
- [ ] textarea内でCtrl/Cmd+Enterを押して投稿が送信されることを確認
- [ ] textarea外で1/2/3キーを押してページ遷移することを確認
- [ ] textarea内で1/2/3キーを押してもページ遷移しないことを確認
- [ ] ?キーでヘルプモーダルが表示されることを確認
- [ ] Escapeキー・オーバーレイクリックでモーダルが閉じることを確認
- [ ] モーダル表示時に閉じるボタンにフォーカスが移ることを確認

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)