### PR TITLE
feat: Firebase本番設定 + GitHub Pagesデプロイ基盤 (#37)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,72 @@
+# GitHub Pages デプロイワークフロー
+# mainブランチへのpush時に自動ビルド・デプロイする
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: front/pnpm-lock.yaml
+
+      - name: Install dependencies
+        working-directory: front
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        working-directory: front
+        env:
+          VITE_BASE_PATH: /${{ github.event.repository.name }}/
+          VITE_FIREBASE_API_KEY: ${{ secrets.VITE_FIREBASE_API_KEY }}
+          VITE_FIREBASE_AUTH_DOMAIN: ${{ secrets.VITE_FIREBASE_AUTH_DOMAIN }}
+          VITE_FIREBASE_PROJECT_ID: ${{ secrets.VITE_FIREBASE_PROJECT_ID }}
+          VITE_FIREBASE_STORAGE_BUCKET: ${{ secrets.VITE_FIREBASE_STORAGE_BUCKET }}
+          VITE_FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.VITE_FIREBASE_MESSAGING_SENDER_ID }}
+          VITE_FIREBASE_APP_ID: ${{ secrets.VITE_FIREBASE_APP_ID }}
+        run: pnpm build
+
+      # SPA用: 404.htmlにindex.htmlをコピー（GitHub Pagesのルーティング対応）
+      - name: Copy index.html to 404.html
+        working-directory: front
+        run: cp dist/index.html dist/404.html
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: front/dist
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/back/firestore.rules
+++ b/back/firestore.rules
@@ -1,10 +1,38 @@
 rules_version = '2';
 
-// ローカルEmulator専用ルール — 本番環境では使用しない
+/**
+ * Firestoreセキュリティルール
+ * 認証なし（viewerId固定）のプロトタイプアプリ用
+ * 読み取りは全公開、書き込みはデータ構造のバリデーションで最低限の保護
+ * @see doc/input/rdd.md §非機能要件
+ */
 service cloud.firestore {
   match /databases/{database}/documents {
-    match /{document=**} {
-      allow read, write: if true;
+
+    // usersコレクション: 読み取り公開、書き込み禁止（シードデータのみ）
+    match /users/{userId} {
+      allow read: if true;
+      allow write: if false;
+    }
+
+    // postsコレクション: 読み取り公開、書き込みはバリデーション付き
+    match /posts/{postId} {
+      allow read: if true;
+      allow create: if request.resource.data.keys().hasAll(['authorId', 'content', 'createdAt'])
+                    && request.resource.data.content is string
+                    && request.resource.data.content.size() > 0
+                    && request.resource.data.content.size() <= 140;
+      allow update, delete: if false;
+    }
+
+    // followsコレクション: 読み取り公開、書き込みはバリデーション付き
+    match /follows/{followId} {
+      allow read: if true;
+      allow create: if request.resource.data.keys().hasAll(['followerId', 'followeeId', 'createdAt'])
+                    && request.resource.data.followerId is string
+                    && request.resource.data.followeeId is string;
+      allow delete: if true;
+      allow update: if false;
     }
   }
 }

--- a/doc/manual/firebase-deploy.md
+++ b/doc/manual/firebase-deploy.md
@@ -1,0 +1,254 @@
+# Firebase本番設定 + GitHub Pagesデプロイ
+
+最終更新: 2026-03-22 / 対象: Firebase + GitHub Pages / 想定読者: 開発者（プロジェクトオーナー）
+
+## 変更履歴
+- 2026-03-22: 初版作成（Issue #37）
+
+## 1. 概要
+- **目的**: ほっとSNSをFirebase本番プロジェクトに接続し、GitHub Pagesで公開する
+- **成果物**: 本番Firestore + GitHub Pagesで動作するSNSアプリ
+- **失敗時の影響**: ローカルEmulator環境は影響なし（本番設定は分離）
+
+## 2. 前提条件
+- OS/シェル: macOS / zsh
+- 必要ツール:
+  - Node.js LTS（.mise.tomlで管理）
+  - pnpm
+  - Firebase CLI（`firebase-tools`）— back/node_modulesにインストール済み
+  - GitHub CLI（`gh`）
+- 権限:
+  - Googleアカウント（Firebase Console操作用）
+  - GitHubリポジトリのAdmin権限（Pages設定用）
+- 参照: doc/input/rdd.md §技術スタック, §非機能要件
+
+---
+
+## 3. 詳細手順
+
+### [S-01] Firebaseにログイン
+- **目的**: Firebase CLIでGoogleアカウントを認証する
+- **実行コマンド**:
+  ```bash
+  cd back
+  npx firebase login
+  ```
+  ブラウザが開くのでGoogleアカウントでログインする。
+- **検証**:
+  ```bash
+  npx firebase projects:list
+  ```
+  **期待結果**: Googleアカウントに紐づくプロジェクト一覧が表示される
+- **注意**: 既にログイン済みなら `Already logged in` と表示される
+
+### [S-02] Firebase本番プロジェクト作成
+- **目的**: Firebase Consoleで本番用プロジェクトを作成する
+- **手順（Firebase Console）**:
+  1. https://console.firebase.google.com/ にアクセス
+  2. 「プロジェクトを追加」をクリック
+  3. プロジェクト名: `hot-sns`（任意、ただし以降の手順ではこの名前を使用）
+  4. Google Analyticsは**無効**にする（学習用プロジェクトのため）
+  5. 「プロジェクトを作成」をクリック
+- **検証**:
+  ```bash
+  npx firebase projects:list
+  ```
+  **期待結果**: `hot-sns` が一覧に表示される
+- **注意**: プロジェクトIDは自動生成される場合がある（例: `hot-sns-12345`）。実際のIDを控えておく
+
+### [S-03] Firestoreデータベースを有効化
+- **目的**: Firebase Consoleで Cloud Firestore を有効にする
+- **手順（Firebase Console）**:
+  1. 作成したプロジェクト → 左メニュー「Firestore Database」
+  2. 「データベースを作成」をクリック
+  3. ロケーション: `asia-northeast1`（東京）を選択
+  4. セキュリティルール: 「テストモードで開始」を選択（後でルールを設定する）
+  5. 「作成」をクリック
+- **検証**: Firebase Console でFirestoreの空のデータベースが表示される
+
+### [S-04] Webアプリを登録してfirebaseConfigを取得
+- **目的**: フロントエンドから接続するための設定情報を取得する
+- **手順（Firebase Console）**:
+  1. プロジェクト設定（歯車アイコン）→「全般」タブ
+  2. 「アプリを追加」→ Webアイコン（`</>`）をクリック
+  3. アプリのニックネーム: `hot-sns-web`
+  4. Firebase Hosting は**チェックしない**（GitHub Pagesを使うため）
+  5. 「アプリを登録」をクリック
+  6. 表示される `firebaseConfig` オブジェクトを**コピーして控える**:
+     ```javascript
+     const firebaseConfig = {
+       apiKey: "<YOUR_API_KEY>",
+       authDomain: "<PROJECT_ID>.firebaseapp.com",
+       projectId: "<PROJECT_ID>",
+       storageBucket: "<PROJECT_ID>.firebasestorage.app",
+       messagingSenderId: "<SENDER_ID>",
+       appId: "<APP_ID>"
+     };
+     ```
+- **注意**: `apiKey` はFirebaseの仕様上フロントに公開される値で、セキュリティはFirestoreルールで担保する
+
+### [S-05] .firebaserc に本番プロジェクトを登録
+- **目的**: Firebase CLIで本番プロジェクトを使えるようにする
+- **実行コマンド**:
+  ```bash
+  cd back
+  npx firebase use --add
+  ```
+  - プロジェクト選択: `<PROJECT_ID>`（S-02で作成したもの）
+  - エイリアス: `production`
+- **検証**:
+  ```bash
+  cat .firebaserc
+  ```
+  **期待結果**:
+  ```json
+  {
+    "projects": {
+      "default": "x-clone-local",
+      "production": "<PROJECT_ID>"
+    }
+  }
+  ```
+- **ロールバック**: `.firebaserc` から `production` エントリを削除
+
+### [S-06] Firestoreセキュリティルールをデプロイ
+- **目的**: 本番Firestoreに適切なセキュリティルールを適用する
+- **前提**: この手順の前に、AIがセキュリティルールファイルを作成する（後述）
+- **実行コマンド**:
+  ```bash
+  cd back
+  npx firebase use production
+  npx firebase deploy --only firestore:rules
+  ```
+- **検証**: Firebase Console → Firestoreルールタブでルールが反映されていることを確認
+- **ロールバック**:
+  ```bash
+  npx firebase use default
+  ```
+  （ローカル開発に戻す）
+
+### [S-07] フロントにfirebaseConfigを設定
+- **目的**: フロントエンドを本番Firestoreに接続する
+- **前提**: この手順の前に、AIが `firebase.ts` を環境分岐対応に修正する（後述）
+- **実行コマンド**:
+  ```bash
+  cd front
+  cp .env.example .env.production
+  ```
+  `.env.production` にS-04で取得した値を記入:
+  ```
+  VITE_FIREBASE_API_KEY=<YOUR_API_KEY>
+  VITE_FIREBASE_AUTH_DOMAIN=<PROJECT_ID>.firebaseapp.com
+  VITE_FIREBASE_PROJECT_ID=<PROJECT_ID>
+  VITE_FIREBASE_STORAGE_BUCKET=<PROJECT_ID>.firebasestorage.app
+  VITE_FIREBASE_MESSAGING_SENDER_ID=<SENDER_ID>
+  VITE_FIREBASE_APP_ID=<APP_ID>
+  ```
+- **注意**: `.env.production` は `.gitignore` に追加済みであること
+
+### [S-08] 本番用ビルド + 動作確認
+- **目的**: 本番設定でビルドし、ローカルでプレビュー確認する
+- **実行コマンド**:
+  ```bash
+  cd front
+  pnpm build
+  pnpm preview
+  ```
+- **検証**: ブラウザで http://localhost:4173 を開き、本番Firestoreのデータが表示されることを確認
+- **注意**: 本番Firestoreにはまだデータがないため、空の画面が表示される。シードデータを投入する場合:
+  ```bash
+  cd back
+  npx firebase use production
+  # seed.tsのEmulator接続部分を本番用に一時変更して実行
+  ```
+
+### [S-09] GitHub Pagesの設定
+- **目的**: GitHub Pagesでの静的サイトホスティングを有効にする
+- **手順（GitHub）**:
+  1. リポジトリ → Settings → Pages
+  2. Source: 「GitHub Actions」を選択
+- **前提**: この手順の前に、AIがGitHub Actionsワークフローを作成する（後述）
+
+### [S-10] GitHub Actionsでデプロイ
+- **目的**: mainブランチへのpush時に自動デプロイする
+- **前提**: AIが `.github/workflows/deploy.yml` を作成済み
+- **実行コマンド**:
+  ```bash
+  git add -A
+  git commit -m "feat: GitHub Pages デプロイ設定"
+  git push origin main
+  ```
+- **検証**:
+  ```bash
+  gh run list --limit 1
+  ```
+  **期待結果**: ワークフローが成功（✓）
+- **確認URL**: `https://<USERNAME>.github.io/<REPO_NAME>/`
+
+### [S-11] GitHub SecretsにFirebase設定を登録（オプション）
+- **目的**: ビルド時に環境変数を注入する（.env.productionをリポジトリに含めない場合）
+- **実行コマンド**:
+  ```bash
+  gh secret set VITE_FIREBASE_API_KEY --body "<YOUR_API_KEY>"
+  gh secret set VITE_FIREBASE_AUTH_DOMAIN --body "<PROJECT_ID>.firebaseapp.com"
+  gh secret set VITE_FIREBASE_PROJECT_ID --body "<PROJECT_ID>"
+  gh secret set VITE_FIREBASE_STORAGE_BUCKET --body "<PROJECT_ID>.firebasestorage.app"
+  gh secret set VITE_FIREBASE_MESSAGING_SENDER_ID --body "<SENDER_ID>"
+  gh secret set VITE_FIREBASE_APP_ID --body "<APP_ID>"
+  ```
+- **検証**: GitHub → Settings → Secrets → 6件のシークレットが登録されている
+
+---
+
+## 4. 確認方法（総合）
+- **本番URL**: `https://<USERNAME>.github.io/<REPO_NAME>/`
+- **期待動作**:
+  - タイムライン画面が表示される
+  - 投稿が可能（Firestoreに保存される）
+  - ユーザー一覧/プロフィール/フォローが動作する
+- **Firebase Console**: Firestoreにデータが保存されていることを確認
+
+---
+
+## 5. トラブルシューティング
+- **[TS-01]** `firebase login` でブラウザが開かない
+  → `npx firebase login --no-localhost` を試す
+- **[TS-02]** `Permission denied` でデプロイ失敗
+  → `npx firebase use production` で正しいプロジェクトが選択されているか確認
+- **[TS-03]** GitHub Pages が404
+  → vite.config.ts の `base` が正しいか確認（`/リポジトリ名/` が必要）
+- **[TS-04]** 本番でFirestoreに接続できない
+  → `.env.production` の値が正しいか確認。Firebase ConsoleでWebアプリの設定を再確認
+- **[TS-05]** CORS エラー
+  → Firebase Consoleで承認済みドメインに `<USERNAME>.github.io` を追加
+
+---
+
+## 6. 完了後の効果
+- 本番環境でSNSアプリが公開され、URLを共有可能
+- Firestoreセキュリティルールで不正アクセスを防止
+- GitHub Actionsで自動デプロイが機能
+
+---
+
+## 7. 付録
+
+### AI側で実装が必要なファイル（手順書実行前に完了させる）
+| ファイル | 内容 |
+|---------|------|
+| `back/firestore.rules` | 本番用セキュリティルール（読み取り許可、書き込み制限） |
+| `front/src/lib/firebase.ts` | 環境分岐（Emulator / 本番）対応 |
+| `front/.env.example` | 環境変数テンプレート |
+| `front/vite.config.ts` | `base` 設定追加（GitHub Pages用） |
+| `.github/workflows/deploy.yml` | GitHub Actions デプロイワークフロー |
+| `front/.gitignore` | `.env.production` 追加 |
+
+### 環境変数一覧
+| 変数名 | 説明 | 例 |
+|--------|------|-----|
+| `VITE_FIREBASE_API_KEY` | Firebase APIキー | `AIzaSy...` |
+| `VITE_FIREBASE_AUTH_DOMAIN` | 認証ドメイン | `hot-sns.firebaseapp.com` |
+| `VITE_FIREBASE_PROJECT_ID` | プロジェクトID | `hot-sns` |
+| `VITE_FIREBASE_STORAGE_BUCKET` | ストレージバケット | `hot-sns.firebasestorage.app` |
+| `VITE_FIREBASE_MESSAGING_SENDER_ID` | メッセージング送信者ID | `123456789` |
+| `VITE_FIREBASE_APP_ID` | アプリID | `1:123:web:abc` |

--- a/front/.env.example
+++ b/front/.env.example
@@ -1,0 +1,9 @@
+# Firebase本番設定（Firebase Consoleから取得）
+# コピーして .env.production を作成し、実際の値を記入する
+# .env.production は .gitignore に含まれており、リポジトリにはコミットされない
+VITE_FIREBASE_API_KEY=
+VITE_FIREBASE_AUTH_DOMAIN=
+VITE_FIREBASE_PROJECT_ID=
+VITE_FIREBASE_STORAGE_BUCKET=
+VITE_FIREBASE_MESSAGING_SENDER_ID=
+VITE_FIREBASE_APP_ID=

--- a/front/.gitignore
+++ b/front/.gitignore
@@ -22,3 +22,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# 本番環境変数（秘密情報を含むためコミットしない）
+.env.production

--- a/front/src/lib/firebase.ts
+++ b/front/src/lib/firebase.ts
@@ -1,16 +1,36 @@
 /**
- * Firebase初期化 + Emulator接続設定
- * ローカル環境専用 — 本番Firebaseプロジェクトには接続しない
+ * Firebase初期化 + 環境分岐設定
+ * ローカル開発時はEmulatorに接続、本番時はFirebase本番プロジェクトに接続する
+ * @see doc/manual/firebase-deploy.md
  */
 import { initializeApp } from 'firebase/app'
 import { getFirestore, connectFirestoreEmulator } from 'firebase/firestore'
 
-const app = initializeApp({ projectId: 'x-clone-local' })
+/**
+ * Firebase設定
+ * 本番: 環境変数（VITE_FIREBASE_*）から取得
+ * ローカル: projectIdのみ指定（Emulator接続）
+ */
+const firebaseConfig = import.meta.env.VITE_FIREBASE_PROJECT_ID
+  ? {
+      apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
+      authDomain: import.meta.env.VITE_FIREBASE_AUTH_DOMAIN,
+      projectId: import.meta.env.VITE_FIREBASE_PROJECT_ID,
+      storageBucket: import.meta.env.VITE_FIREBASE_STORAGE_BUCKET,
+      messagingSenderId: import.meta.env.VITE_FIREBASE_MESSAGING_SENDER_ID,
+      appId: import.meta.env.VITE_FIREBASE_APP_ID,
+    }
+  : { projectId: 'x-clone-local' }
+
+const app = initializeApp(firebaseConfig)
 const db = getFirestore(app)
 
-// Firestore Emulatorに接続（ポート8080）
-// HMR時の二重接続を防止するガード
-if (location.hostname === 'localhost') {
+/**
+ * ローカル開発時のみEmulatorに接続する
+ * 環境変数が未設定（= ローカル開発）の場合にEmulator接続を試みる
+ * HMR時の二重接続を防止するガード付き
+ */
+if (!import.meta.env.VITE_FIREBASE_PROJECT_ID && location.hostname === 'localhost') {
   try {
     connectFirestoreEmulator(db, 'localhost', 8080)
   } catch {

--- a/front/vite.config.ts
+++ b/front/vite.config.ts
@@ -4,4 +4,10 @@ import tailwindcss from '@tailwindcss/vite'
 
 export default defineConfig({
   plugins: [react(), tailwindcss()],
+  /**
+   * GitHub Pages用のベースパス設定
+   * 環境変数 VITE_BASE_PATH が設定されていればそれを使用、なければ '/'
+   * GitHub Actionsで '/リポジトリ名/' を注入する
+   */
+  base: process.env.VITE_BASE_PATH || '/',
 })


### PR DESCRIPTION
## Summary
- Firestoreセキュリティルール（本番用）
- firebase.ts環境分岐（Emulator/本番）
- GitHub Actionsデプロイワークフロー
- デプロイマニュアル

## Changes
- `back/firestore.rules`: 本番用ルール（読み取り公開、書き込みバリデーション）
- `front/src/lib/firebase.ts`: 環境変数による本番/Emulator分岐
- `front/.env.example`: 環境変数テンプレート
- `front/vite.config.ts`: GitHub Pages用base設定
- `.github/workflows/deploy.yml`: 自動デプロイ
- `doc/manual/firebase-deploy.md`: セットアップマニュアル

## Test plan
- [x] lint PASS
- [x] build PASS（ローカルEmulator接続は変更なし）

Closes #37